### PR TITLE
Fix Google login loop

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,16 +1,24 @@
 "use client";
 
-import { useState } from "react";
-import { useRouter } from "next/navigation";
+import { useState, useEffect } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import { signIn } from "next-auth/react";
 import { FcGoogle } from "react-icons/fc";
 
 export default function LoginPage() {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const [login, setLogin] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    const err = searchParams.get("error");
+    if (err) {
+      setError(err);
+    }
+  }, [searchParams]);
   
   const handleGoogle = () => {
     setLoading(true);


### PR DESCRIPTION
## Summary
- capture NextAuth `error` query param on the login page and display it

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bcd8fa1b48332a64b0add69c54c66