### PR TITLE
Fix login build error

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,5 +1,8 @@
 "use client";
 
+// Ensure this route is rendered on the client to avoid build-time errors
+export const dynamic = "force-dynamic";
+
 import { useState, useEffect } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { signIn } from "next-auth/react";


### PR DESCRIPTION
## Summary
- mark the login page as dynamic so it doesn't cause static rendering errors

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bd1ece25883329066b3efdecfcc1f