### PR TITLE
Fix login build issue

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -3,12 +3,12 @@
 // Ensure this route is rendered on the client to avoid build-time errors
 export const dynamic = "force-dynamic";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, Suspense } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { signIn } from "next-auth/react";
 import { FcGoogle } from "react-icons/fc";
 
-export default function LoginPage() {
+function LoginContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const [login, setLogin] = useState("");
@@ -149,5 +149,13 @@ export default function LoginPage() {
         </a>
       </div>
     </div>
+  );
+}
+
+export default function LoginPage() {
+  return (
+    <Suspense fallback={null}>
+      <LoginContent />
+    </Suspense>
   );
 }


### PR DESCRIPTION
## Summary
- wrap Login page content in a `<Suspense>` boundary

## Testing
- `npm ci` *(fails: 403 Forbidden when trying to download packages)*
- `npm run build` *(fails: `next` not found because dependencies could not be installed)*

------
https://chatgpt.com/codex/tasks/task_e_685bd80096208332a505be36675f3bda