### PR TITLE
Fix: Move NEXTAUTH_SECRET to top-level to resolve NextAuth [NO_SECRET] error

### DIFF
--- a/lib/auth-options.ts
+++ b/lib/auth-options.ts
@@ -166,9 +166,8 @@ export const authOptions: NextAuthOptions = {
     maxAge: 30 * 24 * 60 * 60, // 30 days
     updateAge: 24 * 60 * 60, // 24 hours
   },
-  jwt: {
-    secret: process.env.NEXTAUTH_SECRET,
-  },
+  secret: process.env.NEXTAUTH_SECRET,
+  jwt: {},
   cookies: {
     sessionToken: {
       name: `next-auth.session-token`,


### PR DESCRIPTION
## Summary
- move NEXTAUTH_SECRET from jwt options to top-level `secret` field

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bec4abecc8332a01e7973df6819e8