### PR TITLE
Chore: legal fetch `.maybeSingle()`, add sitemap config, remove legacy builds config

### DIFF
--- a/lib/posts.ts
+++ b/lib/posts.ts
@@ -53,7 +53,7 @@ export async function fetchLegalPage(slug: string): Promise<{ title: string; des
     .from('legal_pages')
     .select('*')
     .eq('slug', slug)
-    .single();
+    .maybeSingle();
 
   if (error) {
     console.error('fetchLegalPage error:', error);

--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -1,0 +1,5 @@
+/** @type {import('next-sitemap').IConfig} */
+module.exports = {
+  siteUrl: process.env.NEXT_PUBLIC_SITE_URL || 'https://interstellarnerd.com',
+  generateRobotsTxt: true,
+};

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,5 @@
 {
   "version": 2,
-  "builds": [{ "src": "next.config.js", "use": "@vercel/next" }],
   "installCommand": "npm install --legacy-peer-deps",
   "env": {
     "NEXT_TELEMETRY_DISABLED": "1"


### PR DESCRIPTION
## Summary
- update `fetchLegalPage` to use `.maybeSingle()` so missing pages don't throw PGRST116
- generate sitemap with new `next-sitemap.config.js`
- remove legacy `builds` array from `vercel.json`

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bfa1f19c08332a88eaf6808ac54fa