### PR TITLE
Fix: pass NEXTAUTH_SECRET to getServerSession in forum page

### DIFF
--- a/app/forum/page.tsx
+++ b/app/forum/page.tsx
@@ -4,7 +4,13 @@ import { authOptions } from "../../lib/auth-options";
 import Link from "next/link";
 
 export default async function ForumPage() {
-  const session = await getServerSession(authOptions);
+  // Debug: confirm the secret is injected at runtime
+  console.log("ForumPage sees NEXTAUTH_SECRET:", !!process.env.NEXTAUTH_SECRET);
+
+  const session = await getServerSession({
+    ...authOptions,
+    secret: process.env.NEXTAUTH_SECRET, // ensure secret is always provided
+  });
 
   if (!session) {
     return (


### PR DESCRIPTION
## Summary
- log `NEXTAUTH_SECRET` at runtime
- ensure the forum page passes `NEXTAUTH_SECRET` to `getServerSession`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c012f50c08332873c3c6fb671cc21