### PR TITLE
Fix NO_SECRET runtime errors

### DIFF
--- a/app/api/change-password/route.ts
+++ b/app/api/change-password/route.ts
@@ -11,7 +11,10 @@ const supabase = createClient(
 
 export async function POST(request: NextRequest) {
   try {
-    const session = await getServerSession(authOptions);
+    const session = await getServerSession({
+      ...authOptions,
+      secret: process.env.NEXTAUTH_SECRET,
+    });
     
     if (!session?.user?.id) {
       return NextResponse.json({ error: "Not authenticated" }, { status: 401 });

--- a/app/forum/page.tsx
+++ b/app/forum/page.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 
 export default async function ForumPage() {
   // Debug: confirm the secret is injected at runtime
-  console.log("ForumPage sees NEXTAUTH_SECRET:", !!process.env.NEXTAUTH_SECRET);
+  console.log("Runtime NEXTAUTH_SECRET value:", process.env.NEXTAUTH_SECRET);
 
   const session = await getServerSession({
     ...authOptions,

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -6,7 +6,11 @@ import { createClient } from "@supabase/supabase-js";
 import ProfileView from "../../components/ProfileView";
 
 export default async function ProfilePage() {
-  const session = await getServerSession(authOptions);
+  console.log("Runtime NEXTAUTH_SECRET value:", process.env.NEXTAUTH_SECRET);
+  const session = await getServerSession({
+    ...authOptions,
+    secret: process.env.NEXTAUTH_SECRET,
+  });
   console.log('Server profile session', session);
   if (!session?.user?.id) {
     redirect("/login");


### PR DESCRIPTION
## Summary
- log NEXTAUTH_SECRET at runtime
- supply secret when calling `getServerSession`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c031185a483329cc23dc66ad95b79