### PR TITLE
Add NEXTAUTH secret debug logging

### DIFF
--- a/app/forum/page.tsx
+++ b/app/forum/page.tsx
@@ -4,8 +4,10 @@ import { authOptions } from "../../lib/auth-options";
 import Link from "next/link";
 
 export default async function ForumPage() {
-  // Debug: confirm the secret is injected at runtime
-  console.log("Runtime NEXTAUTH_SECRET value:", process.env.NEXTAUTH_SECRET);
+  console.log(
+    "NEXTAUTH_SECRET available:",
+    !!process.env.NEXTAUTH_SECRET
+  );
 
   const session = await getServerSession({
     ...authOptions,

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -6,7 +6,10 @@ import { createClient } from "@supabase/supabase-js";
 import ProfileView from "../../components/ProfileView";
 
 export default async function ProfilePage() {
-  console.log("Runtime NEXTAUTH_SECRET value:", process.env.NEXTAUTH_SECRET);
+  console.log(
+    "NEXTAUTH_SECRET available:",
+    !!process.env.NEXTAUTH_SECRET
+  );
   const session = await getServerSession({
     ...authOptions,
     secret: process.env.NEXTAUTH_SECRET,


### PR DESCRIPTION
## Summary
- log NEXTAUTH secret availability from server pages
- ensure getServerSession always includes secret

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c0abf69208332ba8ee45f2c77b82f