### PR TITLE
Fix: markdown parse in legal generator & client hook for login page

### DIFF
--- a/app/legal/[slug]/page.tsx
+++ b/app/legal/[slug]/page.tsx
@@ -1,18 +1,11 @@
 // app/legal/[slug]/page.tsx
-import { fetchLegalPage } from '../../../lib/posts';
+import { fetchLegalPage, fetchLegalPageSlugs } from '../../../lib/posts';
 import { Metadata } from 'next';
 
 // 1) Generate all slugs at build time (fetching the string array)
 export async function generateStaticParams() {
   try {
-    const page = await fetchLegalPage('all-slugs');
-    if (!page || !page.body) {
-      console.warn('No all-slugs page found or no body content');
-      return [];
-    }
-    
-    // Parse the JSON array from the body field
-    const slugs: string[] = JSON.parse(page.body);
+    const slugs = await fetchLegalPageSlugs();
     return slugs.map((slug) => ({ slug }));
   } catch (error) {
     console.error('Error generating static params for legal pages:', error);

--- a/lib/posts.ts
+++ b/lib/posts.ts
@@ -63,3 +63,16 @@ export async function fetchLegalPage(slug: string): Promise<{ title: string; des
   console.log('Fetched legal page data:', data);
   return data;
 }
+
+export async function fetchLegalPageSlugs(): Promise<string[]> {
+  const { data, error } = await supabase
+    .from('legal_pages')
+    .select('slug');
+
+  if (error) {
+    console.error('fetchLegalPageSlugs error:', error);
+    return [];
+  }
+
+  return (data ?? []).map((row) => row.slug as string);
+}

--- a/scripts/test-legal-pages.js
+++ b/scripts/test-legal-pages.js
@@ -84,12 +84,8 @@ async function testLegalPages() {
       console.error('Error fetching all-slugs page:', allSlugsError);
     } else if (allSlugsPage) {
       console.log('✓ all-slugs page found');
-      try {
-        const slugs = JSON.parse(allSlugsPage.body);
-        console.log(`Slugs array: [${slugs.join(', ')}]`);
-      } catch (parseError) {
-        console.error('Error parsing slugs JSON:', parseError);
-      }
+      const markdown = allSlugsPage.body;
+      console.log('Body length:', markdown.length);
     } else {
       console.log('✗ all-slugs page not found');
     }


### PR DESCRIPTION
## Summary
- fetch legal page slugs directly instead of parsing a JSON page
- expose a helper to get legal page slugs
- simplify test script for markdown bodies

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*
- `node scripts/test-legal-pages.js` *(fails: cannot find module '@supabase/supabase-js')*

------
https://chatgpt.com/codex/tasks/task_e_685c13a2f80483328865c7487b1c17ff