### PR TITLE
Fix Navbar asset import and ensure layout components

### DIFF
--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -1,0 +1,16 @@
+import Link from "next/link";
+
+export default function Footer() {
+  return (
+    <footer className="bg-spacex text-spacex-gray border-t border-white/10 mt-16 font-sans">
+      <div className="container mx-auto p-6 flex flex-col sm:flex-row justify-between items-center gap-4">
+        <p className="text-xs">&copy; {new Date().getFullYear()} Interstellar Nerd</p>
+        <nav className="space-x-6 text-sm">
+          <Link href="/legal/privacy" className="hover:text-primary transition-colors">Privacy</Link>
+          <Link href="/legal/terms" className="hover:text-primary transition-colors">Terms</Link>
+          <Link href="/legal/cookie-policy" className="hover:text-primary transition-colors">Cookies</Link>
+        </nav>
+      </div>
+    </footer>
+  );
+}

--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import Image from "next/image";
-import { LOGO_URL } from "../lib/assets";
+import { LOGO_URL } from "@/lib/assets";
 import { usePathname, useRouter } from "next/navigation";
 import { Menu, Search } from "lucide-react";
 import { motion } from "framer-motion";


### PR DESCRIPTION
## Summary
- fix asset import in Navbar to use project alias
- add app-level Footer component so layout imports work

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c4a96f2688332b0ff243712f88d2f