### PR TITLE
Update signup to handle OAuth password cases

### DIFF
--- a/app/api/signup/route.ts
+++ b/app/api/signup/route.ts
@@ -1,12 +1,14 @@
-// app/api/signup/route.ts
 import { NextResponse } from "next/server";
 import bcrypt from "bcryptjs";
 import { createClient } from "@supabase/supabase-js";
+import crypto from "crypto";
 
 const supabase = createClient(
   process.env.NEXT_PUBLIC_SUPABASE_URL!,
   process.env.SUPABASE_SERVICE_ROLE_KEY!
 );
+
+function uuid() { return crypto.randomUUID(); }
 
 export async function POST(req: Request) {
   const { email, password } = await req.json();
@@ -15,22 +17,69 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: "Missing fields" }, { status: 400 });
   }
 
+  const { data: existing } = await supabase
+    .from("users")
+    .select("id, hashed_password")
+    .eq("email", email)
+    .maybeSingle();
+
   const hashed = await bcrypt.hash(password, 10);
 
-  const { data, error } = await supabase
+  // A: User exists but no password yet → set password
+  if (existing && !existing.hashed_password) {
+    const { error: updErr } = await supabase
+      .from("users")
+      .update({ hashed_password: hashed })
+      .eq("id", existing.id);
+
+    if (updErr) {
+      console.error("Set-password failed:", updErr);
+      return NextResponse.json({ error: "set_password_error" }, { status: 500 });
+    }
+
+    await ensureProfile(existing.id, email);
+    return NextResponse.json({ ok: true, setPassword: true });
+  }
+
+  // B: User exists and already has a password → reject
+  if (existing) {
+    return NextResponse.json(
+      { exists: true, message: "Account already exists with password" },
+      { status: 409 }
+    );
+  }
+
+  // C: New user → insert and create profile
+  const { data: user, error } = await supabase
     .from("users")
-    .upsert({ email, hashed_password: hashed }, { onConflict: "email" })
+    .insert({ email, hashed_password: hashed })
     .select()
     .single();
 
   if (error) {
-    console.error("Signup failed:", error);
-    return NextResponse.json({ error: "signup_error" }, { status: 400 });
+    console.error("Signup failed:", error.message);
+    return NextResponse.json({ error: "signup_error" }, { status: 500 });
   }
 
-  if (data?.id) {
-    await supabase.from("profiles").upsert({ id: data.id }, { onConflict: "id" });
-  }
-
+  await ensureProfile(user.id, email);
   return NextResponse.json({ ok: true });
+}
+
+// helper: create profile if it doesn’t exist
+async function ensureProfile(userId: string, email: string) {
+  const { data: prof } = await supabase
+    .from("profiles")
+    .select("id")
+    .eq("user_id", userId)
+    .maybeSingle();
+
+  if (!prof) {
+    await supabase.from("profiles").insert({
+      id: uuid(),
+      user_id: userId,
+      username: email.split("@")[0],
+      avatar_url: null,
+      bio: null,
+    });
+  }
 }


### PR DESCRIPTION
## Summary
- handle signup for existing OAuth users without passwords
- deny signup if user already has a password
- ensure profiles table always has entry

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c5f059e5c8332a306364e0d74f651