### PR TITLE
Fix signup username insert

### DIFF
--- a/app/api/signup/route.ts
+++ b/app/api/signup/route.ts
@@ -50,10 +50,15 @@ export async function POST(req: Request) {
   }
 
   // C: New user → insert and create profile
+  const normalizedEmail = email.toLowerCase().trim();
+  const username = normalizedEmail.split("@")[0];
+
   const { data: user, error } = await supabase
     .from("users")
-    .insert({ email, hashed_password: hashed })
-    .select()
+    .insert(
+      { email: normalizedEmail, hashed_password: hashed, username },
+      { returning: "representation" }
+    )
     .single();
 
   if (error) {


### PR DESCRIPTION
## Summary
- supply `username` on signup to satisfy NOT NULL constraint

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685c62ba66b48332bd32539225ed5542