### PR TITLE
Enable Supabase signup w/ NextAuth

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,5 @@
+NEXTAUTH_URL=https://nerd-project.vercel.app
+NEXT_PUBLIC_SUPABASE_URL=your-supabase-url
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+GOOGLE_CLIENT_ID=your-google-client-id
+GOOGLE_CLIENT_SECRET=your-google-client-secret

--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,19 +1,50 @@
-// app/api/auth/[...nextauth]/route.ts
 import NextAuth from "next-auth";
-import GoogleProvider from "next-auth/providers/google";
 import CredentialsProvider from "next-auth/providers/credentials";
-import { authOptions as sharedAuthOptions } from "../../../../lib/auth-options";
+import GoogleProvider from "next-auth/providers/google";
+import { createClient } from "@supabase/supabase-js";
+import bcrypt from "bcryptjs";
 
-console.log("NEXTAUTH_URL:", process.env.NEXTAUTH_URL);
-console.log("NEXTAUTH_URL_INTERNAL:", process.env.NEXTAUTH_URL_INTERNAL);
-console.log(
-  "Google provider config:",
-  (sharedAuthOptions.providers || []).find((p) => p.id === "google")
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!
 );
-console.log("redirect:", sharedAuthOptions.callbacks?.redirect);
-console.log("Session strategy:", sharedAuthOptions.session?.strategy);
-console.log("JWT secret set:", !!sharedAuthOptions.jwt?.secret);
 
-const handler = NextAuth(sharedAuthOptions);
+export const authOptions = {
+  providers: [
+    GoogleProvider({
+      clientId: process.env.GOOGLE_CLIENT_ID!,
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
+    }),
+    CredentialsProvider({
+      name: "Credentials",
+      credentials: {
+        email: { label: "Email", type: "text" },
+        password: { label: "Password", type: "password" },
+      },
+      async authorize(creds) {
+        const { email, password } = creds as any;
+        const { data: user } = await supabase
+          .from("users")
+          .select("*")
+          .eq("email", email)
+          .maybeSingle();
 
+        if (!user?.hashed_password) return null;
+        const valid = await bcrypt.compare(password, user.hashed_password);
+        if (!valid) return null;
+
+        return { id: user.id, email: user.email, name: user.username };
+      },
+    }),
+  ],
+  session: { strategy: "jwt" },
+  callbacks: {
+    async session({ session, token }) {
+      if (token?.sub) session.user.id = token.sub;
+      return session;
+    },
+  },
+};
+
+const handler = NextAuth(authOptions);
 export { handler as GET, handler as POST };

--- a/app/api/auth/signup/route.ts
+++ b/app/api/auth/signup/route.ts
@@ -1,0 +1,79 @@
+import { NextResponse } from "next/server";
+import bcrypt from "bcryptjs";
+import { createClient } from "@supabase/supabase-js";
+import crypto from "crypto";
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!
+);
+
+function uuid() {
+  return crypto.randomUUID();
+}
+
+export async function POST(req: Request) {
+  const { email, password } = await req.json();
+  if (!email || !password) {
+    return NextResponse.json({ error: "Missing fields" }, { status: 400 });
+  }
+
+  const normalizedEmail = email.toLowerCase().trim();
+  const username = normalizedEmail.split("@")[0];
+  const hashed = await bcrypt.hash(password, 10);
+
+  // Does user already exist?
+  const { data: existing } = await supabase
+    .from("users")
+    .select("id, hashed_password")
+    .eq("email", normalizedEmail)
+    .maybeSingle();
+
+  // A) user exists & already has a password  → reject
+  if (existing?.hashed_password) {
+    return NextResponse.json(
+      { error: "Account already exists" },
+      { status: 409 }
+    );
+  }
+
+  const userId = existing?.id || uuid();
+
+  // B) user exists but no password (Google OAuth) → set password
+  if (existing && !existing.hashed_password) {
+    await supabase
+      .from("users")
+      .update({ hashed_password: hashed })
+      .eq("id", userId);
+  }
+
+  // C) brand-new user → insert
+  if (!existing) {
+    await supabase.from("users").insert({
+      id: userId,
+      email: normalizedEmail,
+      username,
+      hashed_password: hashed,
+    });
+  }
+
+  // Ensure profile row
+  const { data: prof } = await supabase
+    .from("profiles")
+    .select("id")
+    .eq("user_id", userId)
+    .maybeSingle();
+
+  if (!prof) {
+    await supabase.from("profiles").insert({
+      id: uuid(),
+      user_id: userId,
+      username,
+      avatar_url: null,
+      bio: null,
+    });
+  }
+
+  // success → let client call signIn()
+  return NextResponse.json({ ok: true });
+}

--- a/app/lib/SignupForm.tsx
+++ b/app/lib/SignupForm.tsx
@@ -1,0 +1,53 @@
+"use client";
+import { useState } from "react";
+import { signIn } from "next-auth/react";
+import { useRouter } from "next/navigation";
+
+export default function SignupForm() {
+  const [email, setEmail] = useState("");
+  const [pw1, setPw1] = useState("");
+  const [pw2, setPw2] = useState("");
+  const [error, setError] = useState("");
+  const router = useRouter();
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError("");
+
+    if (pw1 !== pw2) {
+      setError("Passwords do not match");
+      return;
+    }
+
+    const res = await fetch("/api/auth/signup", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email, password: pw1 }),
+    });
+
+    if (!res.ok) {
+      const { error } = await res.json();
+      setError(error || "Signup failed");
+      return;
+    }
+
+    const result = await signIn("credentials", {
+      email,
+      password: pw1,
+      redirect: false,
+    });
+
+    if (result?.ok) router.push("/");
+    else setError("Auto-login failed");
+  }
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <input type="email" value={email} onChange={(e) => setEmail(e.target.value)} placeholder="Email" required />
+      <input type="password" value={pw1} onChange={(e) => setPw1(e.target.value)} placeholder="Password" required />
+      <input type="password" value={pw2} onChange={(e) => setPw2(e.target.value)} placeholder="Confirm Password" required />
+      <button type="submit">Sign Up</button>
+      {error && <p className="text-red-500">{error}</p>}
+    </form>
+  );
+}

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -32,7 +32,7 @@ export default function SignupPage() {
     const pwd = password;
 
     // 1️⃣ Sign up via API
-    const res = await fetch("/api/signup", {
+    const res = await fetch("/api/auth/signup", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ email: trimmedEmail, password: pwd }),


### PR DESCRIPTION
## Summary
- create `/api/auth/signup` endpoint for credential signup
- add `SignupForm` client component for posting to the new endpoint
- simplify NextAuth configuration to use Supabase directly
- update signup page to call the new API
- document environment variables

## Testing
- `pnpm dev` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c705c07fc8332aee288892f191647