### PR TITLE
Remove duplicate models from Prisma schema

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -149,22 +149,3 @@ model AdminSession {
   @@index([user_id])
   @@index([token])
 }
-
-model users {
-  id      String    @id @default(uuid())
-  threads threads[] @relation("UserThreads")
-  comments Comment[] @relation("UserComments")
-}
-
-model threads {
-  id        String    @id @default(uuid())
-  title     String
-  body      String?
-  user_id   String
-  user      users     @relation("UserThreads", fields: [user_id], references: [id])
-  category  String?
-  createdAt DateTime  @default(now())
-  comments  Comment[] @relation("ThreadComments")
-
-  @@map("threads")
-}


### PR DESCRIPTION
## Summary
- clean up `schema.prisma` by removing extra `users` and `threads` models

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d8709ec4c83328b66903e53ad19c1