### PR TITLE
Remove unused Thread type import

### DIFF
--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,4 +1,4 @@
-import { PrismaClient, type Thread } from "@prisma/client";
+import { PrismaClient } from "@prisma/client";
 
 const globalForPrisma = globalThis as unknown as { prisma: PrismaClient };
 
@@ -16,7 +16,7 @@ export async function getThreadsByCategory(category: string) {
     orderBy: { createdAt: "desc" },
     include: { _count: { select: { comments: true } } }
   });
-  return threads.map((t: Thread & { _count: { comments: number } }) => ({
+  return threads.map((t) => ({
     id: t.id,
     title: t.title,
     categorySlug: t.category,


### PR DESCRIPTION
## Summary
- fix build error by removing the `Thread` type import from Prisma client

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d8ee35328833289292cb895d61e94