### PR TITLE
Fix router.asPath usage for Next.js App Router

### DIFF
--- a/app/admin/generate/page.tsx
+++ b/app/admin/generate/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useSession } from "next-auth/react";
-import { useRouter } from "next/navigation";
+import { useRouter, usePathname } from "next/navigation";
 import { useEffect, useState } from "react";
 import { ArrowLeft, Sparkles, Eye, Edit, Save, RotateCcw } from "lucide-react";
 
@@ -32,6 +32,7 @@ interface GeneratedContent {
 export default function GenerateContent() {
   const { data: session, status } = useSession();
   const router = useRouter();
+  const pathname = usePathname();
   const [category, setCategory] = useState("");
   const [customPrompt, setCustomPrompt] = useState("");
   const [generating, setGenerating] = useState(false);
@@ -43,7 +44,7 @@ export default function GenerateContent() {
     if (status === "loading") return;
     
     if (!session) {
-      router.push(`/login?callbackUrl=${router.asPath}`);
+      router.push(`/login?callbackUrl=${pathname}`);
       return;
     }
 

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useSession } from "next-auth/react";
-import { useRouter } from "next/navigation";
+import { useRouter, usePathname } from "next/navigation";
 import { useEffect, useState } from "react";
 import { 
   Plus, 
@@ -45,6 +45,7 @@ interface AdminStats {
 export default function AdminDashboard() {
   const { data: session, status } = useSession();
   const router = useRouter();
+  const pathname = usePathname();
   const [posts, setPosts] = useState<Post[]>([]);
   const [stats, setStats] = useState<AdminStats | null>(null);
   const [loading, setLoading] = useState(true);
@@ -57,7 +58,7 @@ export default function AdminDashboard() {
     if (status === "loading") return;
     
     if (!session) {
-      router.push(`/login?callbackUrl=${router.asPath}`);
+      router.push(`/login?callbackUrl=${pathname}`);
       return;
     }
 

--- a/app/clear-session/page.tsx
+++ b/app/clear-session/page.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import { signOut } from "next-auth/react";
-import { useRouter } from "next/navigation";
+import { useRouter, usePathname } from "next/navigation";
 import { useEffect } from "react";
 
 export default function ClearSessionPage() {
   const router = useRouter();
+  const pathname = usePathname();
 
   useEffect(() => {
     const clearSession = async () => {
@@ -17,10 +18,10 @@ export default function ClearSessionPage() {
         await signOut({ redirect: false });
         
         // Redirect to login
-        router.push(`/login?callbackUrl=${router.asPath}`);
+        router.push(`/login?callbackUrl=${pathname}`);
       } catch (error) {
         console.error("Error clearing session:", error);
-        router.push(`/login?callbackUrl=${router.asPath}`);
+        router.push(`/login?callbackUrl=${pathname}`);
       }
     };
 

--- a/app/reset-password/page.tsx
+++ b/app/reset-password/page.tsx
@@ -2,12 +2,13 @@
 "use client";
 
 import { useEffect, useState, useMemo } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, usePathname } from "next/navigation";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 
 export default function ResetPasswordPage() {
   const supabase = useMemo(() => createClientComponentClient(), []);
   const router = useRouter();
+  const pathname = usePathname();
 
   const [password, setPassword] = useState("");
   const [status, setStatus] = useState<"idle" | "success" | "error">("idle");
@@ -26,7 +27,7 @@ export default function ResetPasswordPage() {
       setStatus("error");
     } else {
       setStatus("success");
-      setTimeout(() => router.push(`/login?callbackUrl=${router.asPath}`), 2000);
+      setTimeout(() => router.push(`/login?callbackUrl=${pathname}`), 2000);
     }
   };
 

--- a/app/set-password/page.tsx
+++ b/app/set-password/page.tsx
@@ -2,13 +2,14 @@
 "use client";
 
 import { useSession } from "next-auth/react";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useRouter, useSearchParams, usePathname } from "next/navigation";
 import { useEffect, useState, Suspense } from "react";
 import { signIn } from "next-auth/react";
 
 function SetPasswordContent() {
   const { data: session, status, update } = useSession();
   const router = useRouter();
+  const pathname = usePathname();
   const searchParams = useSearchParams();
   const [success, setSuccess] = useState(false);
   const [password, setPassword] = useState("");
@@ -205,7 +206,7 @@ function SetPasswordContent() {
         } else {
           // If auto-login fails, redirect to login page
           setTimeout(() => {
-            router.push(`/login?callbackUrl=${router.asPath}`);
+            router.push(`/login?callbackUrl=${pathname}`);
           }, 1500);
         }
       }


### PR DESCRIPTION
## Summary
- use `usePathname()` instead of deprecated `router.asPath`
- ensure components import `usePathname` and pass it to login redirects

## Testing
- `npm run build` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685da476c1f48332a1719faff4e0ebec