### PR TITLE
Fix type inference in getThreadsByCategory

### DIFF
--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from "@prisma/client";
+import { PrismaClient, type Thread } from "@prisma/client";
 
 const globalForPrisma = globalThis as unknown as { prisma: PrismaClient };
 
@@ -16,7 +16,7 @@ export async function getThreadsByCategory(category: string) {
     orderBy: { createdAt: "desc" },
     include: { _count: { select: { comments: true } } }
   });
-  return threads.map((t) => ({
+  return threads.map((t: Thread & { _count: { comments: number } }) => ({
     id: t.id,
     title: t.title,
     categorySlug: t.category,


### PR DESCRIPTION
## Summary
- adjust prisma helper to explicitly type threads

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find type definition file)*

------
https://chatgpt.com/codex/tasks/task_e_685daaddb4b48332b96a60f9ef53dd22