### PR TITLE
Fix Edge runtime middleware import

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,21 +1,25 @@
-// middleware.ts
 import { withAuth } from "next-auth/middleware";
-import { authOptions } from "./lib/auth-options";
 
 export default withAuth({
-  ...authOptions,
+  cookies: {
+    sessionToken: {
+      name: "next-auth.session-token",
+      options: {
+        httpOnly: true,
+        sameSite: "lax",
+        path: "/",
+        secure: true,
+      },
+    },
+  },
   callbacks: {
     authorized: ({ token }) => {
-      console.log("🧪 MIDDLEWARE token:", token);
+      console.log("🧪 MIDDLEWARE token:", token); // keep for debugging
       return !!token;
     },
   },
 });
 
 export const config = {
-  matcher: [
-    "/profile/:path*",
-    "/admin/:path*",
-    "/api/admin/:path*",
-  ],
+  matcher: ["/profile/:path*", "/admin/:path*", "/api/admin/:path*"],
 };


### PR DESCRIPTION
## Summary
- remove server-only `authOptions` import from middleware
- define session cookie inline to avoid Edge runtime dynamic evaluation

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dbb4463dc83329535b1c9cef6466f