### PR TITLE
Handle oauth-only login

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -103,6 +103,11 @@ function LoginContent() {
 
       console.log("Sign in result:", res);
 
+      if (res?.error?.toUpperCase().includes("OAUTH_ONLY")) {
+        router.push(`/set-password?email=${encodeURIComponent(email)}`);
+        return;
+      }
+
       if (res?.error) {
         setError("Invalid email or password");
         return;

--- a/lib/auth-options.ts
+++ b/lib/auth-options.ts
@@ -258,7 +258,9 @@ export const authOptions: NextAuthOptions = {
 
         // Check if user exists but has no password (OAuth-only account)
         if (!user.hashed_password) {
-          return null; // Return null to indicate invalid credentials
+          const error = new Error("OAUTH_ONLY");
+          (error as any).code = "OAUTH_ONLY";
+          throw error;
         }
 
         // Verify password


### PR DESCRIPTION
## Summary
- throw OAUTH_ONLY error for OAuth-only accounts during credential login
- redirect OAuth-only users to set password page

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685dc1f7750c8332b94df31d5f643831