### PR TITLE
Handle OAuth-only login redirect

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -82,10 +82,10 @@ function LoginContent() {
       if (checkRes.ok) {
         const accountData = await checkRes.json();
         console.log("Account data:", accountData);
-        
+
         if (accountData.accountType === "oauth-only") {
-          console.log("OAuth-only account detected - showing error message");
-          setError("This account was created with Google. Please sign in with Google, or set a password to enable email/password sign-in.");
+          console.log("OAuth-only account detected - redirecting to set password");
+          router.push(`/set-password?email=${encodeURIComponent(email)}`);
           setLoading(false);
           return;
         }


### PR DESCRIPTION
## Summary
- update login form to check account type first
- redirect OAuth-only users to the set password page instead of trying credential login

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dc48e46e4833284a5bd14cb4d4f13