### PR TITLE
Fix set password page loop

### DIFF
--- a/app/set-password/page.tsx
+++ b/app/set-password/page.tsx
@@ -4,20 +4,29 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "../../lib/auth-options";
 import SetPasswordForm from "../../components/SetPasswordForm";
 
-export default async function SetPasswordPage() {
+interface SetPasswordPageProps {
+  searchParams: Promise<{ email?: string }>;
+}
+
+export default async function SetPasswordPage({
+  searchParams,
+}: SetPasswordPageProps) {
   const session = await getServerSession({
     ...authOptions,
     secret: process.env.NEXTAUTH_SECRET,
   });
 
-  if (!session?.user?.email) {
+  const { email: queryEmail } = await searchParams;
+  const email = session?.user?.email || queryEmail;
+
+  if (!email) {
     redirect("/login");
   }
 
   return (
     <div className="max-w-md mx-auto py-12 space-y-6">
       <h1 className="text-3xl font-orbitron text-center">Set Your Password</h1>
-      <SetPasswordForm email={session!.user.email} />
+      <SetPasswordForm email={email} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- allow unauthenticated users with `?email` query to access the set-password page

## Testing
- `npm run lint` *(fails: `next: not found`)*
- `npm run build` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685ddf49877083328feb8e19f35e5007