### PR TITLE
Fix unauth set-password flow

### DIFF
--- a/app/api/set-password-unauth/route.ts
+++ b/app/api/set-password-unauth/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@supabase/supabase-js";
+import bcrypt from "bcryptjs";
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!,
+);
+
+export async function POST(req: Request) {
+  try {
+    const { email, password } = await req.json();
+
+    if (!email || typeof email !== "string") {
+      return NextResponse.json({ error: "Missing email" }, { status: 400 });
+    }
+
+    if (!password || password.length < 6) {
+      return NextResponse.json({ error: "Password too short" }, { status: 400 });
+    }
+
+    const { data: user } = await supabase
+      .from("users")
+      .select("id, hashed_password")
+      .eq("email", email)
+      .maybeSingle();
+
+    if (!user || user.hashed_password) {
+      return NextResponse.json({ error: "Invalid account" }, { status: 400 });
+    }
+
+    const hashed = await bcrypt.hash(password, 12);
+
+    const { error } = await supabase
+      .from("users")
+      .update({ hashed_password: hashed })
+      .eq("id", user.id);
+
+    if (error) {
+      console.error("Set-password-unauth error:", error);
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    console.error("Set-password-unauth unexpected:", err);
+    return NextResponse.json({ error: "Invalid request" }, { status: 400 });
+  }
+}

--- a/app/set-password/page.tsx
+++ b/app/set-password/page.tsx
@@ -18,6 +18,7 @@ export default async function SetPasswordPage({
 
   const { email: queryEmail } = await searchParams;
   const email = session?.user?.email || queryEmail;
+  const unauth = !session?.user?.email;
 
   if (!email) {
     redirect("/login");
@@ -26,7 +27,7 @@ export default async function SetPasswordPage({
   return (
     <div className="max-w-md mx-auto py-12 space-y-6">
       <h1 className="text-3xl font-orbitron text-center">Set Your Password</h1>
-      <SetPasswordForm email={email} />
+      <SetPasswordForm email={email} unauth={unauth} />
     </div>
   );
 }

--- a/components/SetPasswordForm.tsx
+++ b/components/SetPasswordForm.tsx
@@ -3,7 +3,13 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 
-export default function SetPasswordForm({ email }: { email: string }) {
+export default function SetPasswordForm({
+  email,
+  unauth = false,
+}: {
+  email: string;
+  unauth?: boolean;
+}) {
   const router = useRouter();
   const [password, setPassword] = useState("");
   const [confirm, setConfirm] = useState("");
@@ -27,10 +33,13 @@ export default function SetPasswordForm({ email }: { email: string }) {
     setLoading(true);
 
     try {
-      const res = await fetch("/api/set-password", {
+      const endpoint = unauth ? "/api/set-password-unauth" : "/api/set-password";
+      const body = unauth ? { email, password } : { password };
+
+      const res = await fetch(endpoint, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ password }),
+        body: JSON.stringify(body),
       });
 
       const data = await res.json();


### PR DESCRIPTION
## Summary
- add unauth `/api/set-password-unauth` endpoint
- update `SetPasswordForm` to support unauth endpoint
- wire unauth form usage in `app/set-password` page

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685de12e85908332aa5a23d750e5e22d