### PR TITLE
Fix resend version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "react-dom": "18.2.0",
     "react-icons": "5.5.0",
     "tailwindcss": "3.4.1",
-    "resend": "^0.24.0"
+    "resend": "^0.22.0"
   },
   "devDependencies": {
     "@mdx-js/loader": "3.1.0",


### PR DESCRIPTION
## Summary
- correct invalid version for `resend` dependency

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685df5fedc98833281acfd231bf31d1d