### PR TITLE
Update resend version

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "react-dom": "18.2.0",
     "react-icons": "5.5.0",
     "tailwindcss": "3.4.1",
-    "resend": "^0.22.0"
+    "resend": "^0.21.1"
   },
   "devDependencies": {
     "@mdx-js/loader": "3.1.0",


### PR DESCRIPTION
## Summary
- bump `resend` dependency to a valid published version

## Testing
- `npm install` *(fails: unable to reach registry)*

------
https://chatgpt.com/codex/tasks/task_e_685df78873d48332bb8b4eaccb38e7b0