### PR TITLE
Update resend dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "react-dom": "18.2.0",
     "react-icons": "5.5.0",
     "tailwindcss": "3.4.1",
-    "resend": "^0.21.1"
+    "resend": "^4.6.0"
   },
   "devDependencies": {
     "@mdx-js/loader": "3.1.0",


### PR DESCRIPTION
## Summary
- update `resend` dependency version to 4.6.0

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm install` *(fails: 403 Forbidden to registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_685df86c28188332ae99dde85a13efcb