### PR TITLE
Add secure password setup flow for OAuth users

### DIFF
--- a/app/api/send-set-password/route.ts
+++ b/app/api/send-set-password/route.ts
@@ -1,10 +1,11 @@
 import { NextResponse } from "next/server";
 import { createClient } from "@supabase/supabase-js";
 import { Resend } from "resend";
+import crypto from "crypto";
 
 const supabase = createClient(
   process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!
 );
 
 const resend = new Resend(process.env.RESEND_API_KEY!);
@@ -19,7 +20,7 @@ export async function POST(req: Request) {
   const { data: user, error } = await supabase
     .from("users")
     .select("id, hashed_password")
-    .eq("email", email)
+    .eq("email", email.toLowerCase())
     .maybeSingle();
 
   if (error) {
@@ -28,30 +29,55 @@ export async function POST(req: Request) {
   }
 
   if (!user) {
-    return NextResponse.json({ error: "No user found with this email" }, { status: 404 });
+    return NextResponse.json(
+      { error: "No user found with this email" },
+      { status: 404 }
+    );
   }
 
   if (user.hashed_password) {
-    return NextResponse.json({ error: "User already has a password" }, { status: 400 });
+    return NextResponse.json(
+      { error: "User already has a password" },
+      { status: 400 }
+    );
   }
 
   try {
+    const token = crypto.randomBytes(32).toString("hex");
+    const expires = new Date(Date.now() + 60 * 60 * 1000); // 1 hour
+
+    await supabase
+      .from("verification_tokens")
+      .delete()
+      .eq("identifier", `set-password:${user.id}`);
+
+    await supabase.from("verification_tokens").insert({
+      identifier: `set-password:${user.id}`,
+      token,
+      expires: expires.toISOString(),
+    });
+
     const site =
       process.env.NEXT_PUBLIC_SITE_URL || "https://nerd-project.vercel.app";
-    const link = `${site}/set-password?email=${encodeURIComponent(email)}`;
+    const link = `${site}/set-password?token=${token}`;
+
     await resend.emails.send({
       from: "Interstellar Nerd <noreply@interstellarnerd.com>",
       to: email,
       subject: "Set Your Password for Interstellar Nerd",
       html: `
         <h1>Set Your Password</h1>
-        <p>You signed up with Google OAuth but didn't create a password. Use the link below to set one now.</p>
+        <p>We received a request to add a password to your account.</p>
+        <p>Click the link below to create one. This link expires in one hour.</p>
         <p><a href="${link}">Set Password</a></p>
       `,
     });
   } catch (err) {
     console.error("Send-set-password email error:", err);
-    return NextResponse.json({ error: "Failed to send email" }, { status: 500 });
+    return NextResponse.json(
+      { error: "Failed to send email" },
+      { status: 500 }
+    );
   }
 
   return NextResponse.json({ success: true });

--- a/app/api/set-password-unauth/route.ts
+++ b/app/api/set-password-unauth/route.ts
@@ -4,25 +4,47 @@ import bcrypt from "bcryptjs";
 
 const supabase = createClient(
   process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!
 );
 
 export async function POST(req: Request) {
   try {
-    const { email, password } = await req.json();
+    const { token, password } = await req.json();
 
-    if (!email || typeof email !== "string") {
-      return NextResponse.json({ error: "Missing email" }, { status: 400 });
+    if (!token || typeof token !== "string") {
+      return NextResponse.json({ error: "Missing token" }, { status: 400 });
     }
 
     if (!password || password.length < 6) {
-      return NextResponse.json({ error: "Password too short" }, { status: 400 });
+      return NextResponse.json(
+        { error: "Password too short" },
+        { status: 400 }
+      );
     }
+
+    const { data: tokenRow } = await supabase
+      .from("verification_tokens")
+      .select("identifier, expires")
+      .eq("token", token)
+      .maybeSingle();
+
+    if (
+      !tokenRow ||
+      !tokenRow.identifier.startsWith("set-password:") ||
+      new Date(tokenRow.expires).getTime() < Date.now()
+    ) {
+      return NextResponse.json(
+        { error: "Invalid or expired token" },
+        { status: 400 }
+      );
+    }
+
+    const userId = tokenRow.identifier.replace("set-password:", "");
 
     const { data: user } = await supabase
       .from("users")
-      .select("id, hashed_password")
-      .eq("email", email)
+      .select("id, hashed_password, email")
+      .eq("id", userId)
       .maybeSingle();
 
     if (!user || user.hashed_password) {
@@ -35,6 +57,8 @@ export async function POST(req: Request) {
       .from("users")
       .update({ hashed_password: hashed })
       .eq("id", user.id);
+
+    await supabase.from("verification_tokens").delete().eq("token", token);
 
     if (error) {
       console.error("Set-password-unauth error:", error);

--- a/app/set-password/page.tsx
+++ b/app/set-password/page.tsx
@@ -3,9 +3,11 @@ import { redirect } from "next/navigation";
 import { getServerSession } from "next-auth";
 import { authOptions } from "../../lib/auth-options";
 import SetPasswordForm from "../../components/SetPasswordForm";
+import InvalidTokenNotice from "../../components/InvalidTokenNotice";
+import { createClient } from "@supabase/supabase-js";
 
 interface SetPasswordPageProps {
-  searchParams: Promise<{ email?: string }>;
+  searchParams: Promise<{ token?: string }>;
 }
 
 export default async function SetPasswordPage({
@@ -16,18 +18,66 @@ export default async function SetPasswordPage({
     secret: process.env.NEXTAUTH_SECRET,
   });
 
-  const { email: queryEmail } = await searchParams;
-  const email = session?.user?.email || queryEmail;
-  const unauth = !session?.user?.email;
+  const { token } = await searchParams;
 
-  if (!email) {
+  if (session?.user?.email) {
+    return (
+      <div className="max-w-md mx-auto py-12 space-y-6">
+        <h1 className="text-3xl font-orbitron text-center">
+          Set Your Password
+        </h1>
+        <SetPasswordForm email={session.user.email} />
+      </div>
+    );
+  }
+
+  if (!token) {
     redirect("/login");
+  }
+
+  const supabase = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!
+  );
+
+  const { data: tokenRow } = await supabase
+    .from("verification_tokens")
+    .select("identifier, expires")
+    .eq("token", token!)
+    .maybeSingle();
+
+  if (
+    !tokenRow ||
+    !tokenRow.identifier.startsWith("set-password:") ||
+    new Date(tokenRow.expires).getTime() < Date.now()
+  ) {
+    return (
+      <div className="max-w-md mx-auto py-12">
+        <InvalidTokenNotice />
+      </div>
+    );
+  }
+
+  const userId = tokenRow.identifier.replace("set-password:", "");
+
+  const { data: user } = await supabase
+    .from("users")
+    .select("email, hashed_password")
+    .eq("id", userId)
+    .maybeSingle();
+
+  if (!user || user.hashed_password) {
+    return (
+      <div className="max-w-md mx-auto py-12">
+        <InvalidTokenNotice />
+      </div>
+    );
   }
 
   return (
     <div className="max-w-md mx-auto py-12 space-y-6">
       <h1 className="text-3xl font-orbitron text-center">Set Your Password</h1>
-      <SetPasswordForm email={email} unauth={unauth} />
+      <SetPasswordForm email={user.email} unauth token={token!} />
     </div>
   );
 }

--- a/components/InvalidTokenNotice.tsx
+++ b/components/InvalidTokenNotice.tsx
@@ -1,0 +1,11 @@
+"use client";
+import { useEffect } from "react";
+import { toast } from "react-hot-toast";
+
+export default function InvalidTokenNotice() {
+  useEffect(() => {
+    toast.error("Invalid or expired link");
+  }, []);
+
+  return <p className="text-red-600">Invalid or expired link.</p>;
+}


### PR DESCRIPTION
## Summary
- add token-based set password email flow
- update unauthenticated password setup API to verify tokens
- prompt password setup from login page instead of auto email
- validate password tokens on the set-password page
- sign user in after setting password

## Testing
- `npx prettier --write app/api/send-set-password/route.ts app/api/set-password-unauth/route.ts components/SetPasswordForm.tsx app/login/page.tsx app/set-password/page.tsx components/InvalidTokenNotice.tsx`
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685dfe2878dc83328702f4873f381079