### PR TITLE
Add secure password token flow

### DIFF
--- a/app/api/request-set-password/route.ts
+++ b/app/api/request-set-password/route.ts
@@ -1,0 +1,81 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@supabase/supabase-js";
+import { Resend } from "resend";
+import crypto from "crypto";
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!
+);
+
+const resend = new Resend(process.env.RESEND_API_KEY!);
+
+export async function POST(req: Request) {
+  const { email } = await req.json().catch(() => ({}));
+
+  if (!email || typeof email !== "string") {
+    return NextResponse.json({ error: "Missing email" }, { status: 400 });
+  }
+
+  const { data: user, error } = await supabase
+    .from("users")
+    .select("id, hashed_password")
+    .eq("email", email.toLowerCase())
+    .maybeSingle();
+
+  if (error) {
+    console.error("request-set-password lookup error:", error);
+    return NextResponse.json({ error: "Database error" }, { status: 500 });
+  }
+
+  if (!user) {
+    return NextResponse.json(
+      { error: "No user found with this email" },
+      { status: 404 }
+    );
+  }
+
+  if (user.hashed_password) {
+    return NextResponse.json(
+      { error: "User already has a password" },
+      { status: 400 }
+    );
+  }
+
+  const token = crypto.randomBytes(32).toString("hex");
+  const expiresAt = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+
+  // Remove existing tokens for user
+  await supabase.from("password_reset_tokens").delete().eq("user_id", user.id);
+
+  const { error: insertErr } = await supabase
+    .from("password_reset_tokens")
+    .insert({ user_id: user.id, token, expires_at: expiresAt });
+
+  if (insertErr) {
+    console.error("request-set-password insert error:", insertErr);
+    return NextResponse.json({ error: "Database error" }, { status: 500 });
+  }
+
+  const site = process.env.NEXT_PUBLIC_SITE_URL || "https://interstellarnerd.com";
+  const link = `${site}/set-password?token=${token}`;
+
+  try {
+    await resend.emails.send({
+      from: "Interstellar Nerd <noreply@interstellarnerd.com>",
+      to: email,
+      subject: "Set Your Password for Interstellar Nerd",
+      html: `
+        <h1>Set Your Password</h1>
+        <p>We received a request to add a password to your account.</p>
+        <p>Click the link below to create one. This link expires in one hour.</p>
+        <p><a href="${link}">Set Password</a></p>
+      `,
+    });
+  } catch (err) {
+    console.error("request-set-password email error:", err);
+    return NextResponse.json({ error: "Failed to send email" }, { status: 500 });
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/app/api/set-password-from-token/route.ts
+++ b/app/api/set-password-from-token/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@supabase/supabase-js";
+import bcrypt from "bcryptjs";
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!
+);
+
+export async function POST(req: Request) {
+  const { token, password } = await req.json().catch(() => ({}));
+
+  if (!token || typeof token !== "string") {
+    return NextResponse.json({ error: "Missing token" }, { status: 400 });
+  }
+
+  if (!password || typeof password !== "string" || password.length < 6) {
+    return NextResponse.json({ error: "Password too short" }, { status: 400 });
+  }
+
+  const { data: tokenRow } = await supabase
+    .from("password_reset_tokens")
+    .select("user_id, expires_at")
+    .eq("token", token)
+    .maybeSingle();
+
+  if (!tokenRow || new Date(tokenRow.expires_at).getTime() < Date.now()) {
+    return NextResponse.json({ error: "Invalid or expired token" }, { status: 400 });
+  }
+
+  const hashed = await bcrypt.hash(password, 12);
+
+  const { error: updateErr } = await supabase
+    .from("users")
+    .update({ hashed_password: hashed })
+    .eq("id", tokenRow.user_id);
+
+  if (updateErr) {
+    console.error("set-password-from-token update error:", updateErr);
+    return NextResponse.json({ error: "Failed to update password" }, { status: 500 });
+  }
+
+  await supabase.from("password_reset_tokens").delete().eq("token", token);
+
+  return NextResponse.json({ success: true });
+}

--- a/app/api/verify-reset-token/route.ts
+++ b/app/api/verify-reset-token/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@supabase/supabase-js";
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!
+);
+
+export async function POST(req: Request) {
+  const { token } = await req.json().catch(() => ({}));
+
+  if (!token || typeof token !== "string") {
+    return NextResponse.json({ error: "Missing token" }, { status: 400 });
+  }
+
+  const { data } = await supabase
+    .from("password_reset_tokens")
+    .select("user_id, expires_at")
+    .eq("token", token)
+    .maybeSingle();
+
+  if (!data || new Date(data.expires_at).getTime() < Date.now()) {
+    return NextResponse.json({ valid: false });
+  }
+
+  return NextResponse.json({ valid: true, user_id: data.user_id });
+}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -61,7 +61,7 @@ function LoginContent() {
   const handleSendLink = async () => {
     setLoading(true);
     try {
-      const sendRes = await fetch("/api/send-set-password", {
+      const sendRes = await fetch("/api/request-set-password", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ email }),
@@ -154,8 +154,8 @@ function LoginContent() {
       {showSetPasswordPrompt && (
         <div className="p-3 bg-yellow-100 text-yellow-800 rounded space-y-2">
           <p>
-            We found your account. It was created using Google OAuth and doesn't
-            have a password. Would you like to set one?
+            You originally signed up with Google. Click below to set a password
+            to enable email login.
           </p>
           <button
             type="button"

--- a/components/SetPasswordForm.tsx
+++ b/components/SetPasswordForm.tsx
@@ -37,7 +37,7 @@ export default function SetPasswordForm({
 
     try {
       const endpoint = unauth
-        ? "/api/set-password-unauth"
+        ? "/api/set-password-from-token"
         : "/api/set-password";
       const body = unauth ? { token, password } : { password };
       const res = await fetch(endpoint, {


### PR DESCRIPTION
## Summary
- implement password token routes for OAuth users
- link request endpoint from login page
- verify token and set new password on dedicated page
- update set password form to use new API

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e00607f808332a4a37b435780f1a7