### PR TITLE
Add password visibility toggle and collapse mobile nav on load

### DIFF
--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -6,7 +6,7 @@ import { LOGO_URL } from "@/lib/assets";
 import { usePathname, useRouter } from "next/navigation";
 import { Menu, Search } from "lucide-react";
 import { motion } from "framer-motion";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useSession, signOut } from "next-auth/react";
 
 export default function Navbar() {
@@ -14,6 +14,9 @@ export default function Navbar() {
   const user = session?.user;
   const pathname = usePathname();
   const [open, setOpen] = useState(false);
+  useEffect(() => {
+    setOpen(false);
+  }, [pathname]);
   const [search, setSearch] = useState("");
   const router = useRouter();
   const showSearch = pathname === "/";

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -8,6 +8,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { signIn } from "next-auth/react";
 import { toast } from "react-hot-toast";
 import { FcGoogle } from "react-icons/fc";
+import PasswordInput from "@/components/PasswordInput";
 
 function LoginContent() {
   const router = useRouter();
@@ -202,9 +203,8 @@ function LoginContent() {
         <label htmlFor="password" className="sr-only">
           Password
         </label>
-        <input
+        <PasswordInput
           id="password"
-          type="password"
           placeholder="Password"
           className="p-2 w-full rounded text-black"
           value={password}

--- a/app/reset-password/page.tsx
+++ b/app/reset-password/page.tsx
@@ -4,6 +4,7 @@
 import { useEffect, useState, useMemo } from "react";
 import { useRouter, usePathname } from "next/navigation";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import PasswordInput from "@/components/PasswordInput";
 
 export default function ResetPasswordPage() {
   const supabase = useMemo(() => createClientComponentClient(), []);
@@ -36,8 +37,7 @@ export default function ResetPasswordPage() {
       <h1 className="text-2xl font-bold mb-4">Set New Password</h1>
 
       <form onSubmit={handleSubmit} className="space-y-4">
-        <input
-          type="password"
+        <PasswordInput
           placeholder="New password"
           className="p-2 w-full rounded text-black"
           value={password}

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { signIn } from "next-auth/react";
 import { FcGoogle } from "react-icons/fc";
+import PasswordInput from "@/components/PasswordInput";
 
 export default function SignupPage() {
   const router = useRouter();
@@ -89,16 +90,14 @@ export default function SignupPage() {
           onChange={(e) => setEmail(e.target.value)}
           required
         />
-        <input
-          type="password"
+        <PasswordInput
           placeholder="Password"
           className="p-2 w-full rounded text-black"
           value={password}
           onChange={(e) => setPassword(e.target.value)}
           required
         />
-        <input
-          type="password"
+        <PasswordInput
           placeholder="Confirm Password"
           className="p-2 w-full rounded text-black"
           value={confirmPassword}

--- a/components/PasswordInput.tsx
+++ b/components/PasswordInput.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useState } from "react";
+import { HiEye, HiEyeOff } from "react-icons/hi";
+
+export type PasswordInputProps = React.InputHTMLAttributes<HTMLInputElement>;
+
+export default function PasswordInput({ className = "", ...props }: PasswordInputProps) {
+  const [show, setShow] = useState(false);
+  return (
+    <div className="relative">
+      <input
+        {...props}
+        type={show ? "text" : "password"}
+        className={`pr-10 ${className}`.trim()}
+      />
+      <button
+        type="button"
+        onClick={() => setShow((s) => !s)}
+        className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-600"
+        aria-label={show ? "Hide password" : "Show password"}
+      >
+        {show ? <HiEyeOff /> : <HiEye />}
+      </button>
+    </div>
+  );
+}

--- a/components/ProfileView.tsx
+++ b/components/ProfileView.tsx
@@ -5,6 +5,7 @@ import { useState, useEffect, useMemo, ChangeEvent } from "react";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import { useSession } from "next-auth/react";
 import { Edit3, Save, X, User, Calendar, MessageSquare, FileText, Globe, Mail, Lock, Upload, Camera } from "lucide-react";
+import PasswordInput from "@/components/PasswordInput";
 
 interface Profile {
   id: string;
@@ -342,8 +343,7 @@ export default function ProfileView({
                 <label className="block text-sm font-medium text-spacex-gray mb-2">
                   Current Password
                 </label>
-                <input
-                  type="password"
+                <PasswordInput
                   value={currentPassword}
                   onChange={(e) => setCurrentPassword(e.target.value)}
                   className="w-full p-3 rounded-lg bg-background border border-white/10 text-white focus:border-primary focus:outline-none"
@@ -353,8 +353,7 @@ export default function ProfileView({
                 <label className="block text-sm font-medium text-spacex-gray mb-2">
                   New Password
                 </label>
-                <input
-                  type="password"
+                <PasswordInput
                   value={newPassword}
                   onChange={(e) => setNewPassword(e.target.value)}
                   className="w-full p-3 rounded-lg bg-background border border-white/10 text-white focus:border-primary focus:outline-none"
@@ -364,8 +363,7 @@ export default function ProfileView({
                 <label className="block text-sm font-medium text-spacex-gray mb-2">
                   Confirm New Password
                 </label>
-                <input
-                  type="password"
+                <PasswordInput
                   value={confirmPassword}
                   onChange={(e) => setConfirmPassword(e.target.value)}
                   className="w-full p-3 rounded-lg bg-background border border-white/10 text-white focus:border-primary focus:outline-none"

--- a/components/SetPasswordForm.tsx
+++ b/components/SetPasswordForm.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { toast } from "react-hot-toast";
 import { useRouter } from "next/navigation";
 import { useSession, signIn } from "next-auth/react";
+import PasswordInput from "@/components/PasswordInput";
 
 export default function SetPasswordForm({
   email,
@@ -83,9 +84,8 @@ export default function SetPasswordForm({
         <label htmlFor="password" className="sr-only">
           Password
         </label>
-        <input
+        <PasswordInput
           id="password"
-          type="password"
           value={password}
           onChange={(e) => setPassword(e.target.value)}
           required
@@ -97,9 +97,8 @@ export default function SetPasswordForm({
         <label htmlFor="confirm" className="sr-only">
           Confirm Password
         </label>
-        <input
+        <PasswordInput
           id="confirm"
-          type="password"
           value={confirm}
           onChange={(e) => setConfirm(e.target.value)}
           required


### PR DESCRIPTION
## Summary
- add reusable `PasswordInput` component with eye icon toggle
- integrate `PasswordInput` in login, signup, reset-password and set-password forms
- update profile password change modal to use `PasswordInput`
- keep mobile menu collapsed by resetting state on route changes

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e03f287d08332a1c8613a546b3a42