### PR TITLE
Fix admin dashboard checks, persistent dark mode

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -3,18 +3,18 @@
 import { useSession } from "next-auth/react";
 import { useRouter, usePathname } from "next/navigation";
 import { useEffect, useState } from "react";
-import { 
-  Plus, 
-  FileText, 
-  Calendar, 
-  Eye, 
-  Edit, 
-  Trash2, 
+import {
+  Plus,
+  FileText,
+  Calendar,
+  Eye,
+  Edit,
+  Trash2,
   Settings,
   Moon,
   Sun,
   Search,
-  Filter
+  Filter,
 } from "lucide-react";
 
 interface Post {
@@ -56,36 +56,55 @@ export default function AdminDashboard() {
 
   useEffect(() => {
     if (status === "loading") return;
-    
+
     if (!session) {
       router.push(`/login?callbackUrl=${pathname}`);
       return;
     }
 
-    checkAdminStatus();
-    fetchPosts();
-    fetchStats();
+    const verifyAndFetch = async () => {
+      const isAdmin = await checkAdminStatus();
+      if (isAdmin) {
+        fetchPosts();
+        fetchStats();
+      }
+    };
+
+    verifyAndFetch();
   }, [session, status, router]);
 
-  const checkAdminStatus = async () => {
+  useEffect(() => {
+    const stored = localStorage.getItem("darkMode");
+    if (stored !== null) {
+      setDarkMode(stored === "true");
+    }
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem("darkMode", darkMode.toString());
+  }, [darkMode]);
+
+  const checkAdminStatus = async (): Promise<boolean> => {
     try {
       const response = await fetch("/api/check-admin");
-      if (!response.ok) {
-        router.push("/unauthorized");
+      if (response.status === 200) {
+        return true;
       }
+      router.push("/unauthorized");
+      return false;
     } catch (error) {
       console.error("Admin check failed:", error);
       router.push("/unauthorized");
+      return false;
     }
   };
 
   const fetchPosts = async () => {
     try {
       const response = await fetch("/api/admin/posts");
-      if (response.ok) {
-        const data = await response.json();
-        setPosts(data.posts);
-      }
+      if (!response.ok) return;
+      const data = await response.json();
+      setPosts(data.posts);
     } catch (error) {
       console.error("Failed to fetch posts:", error);
     } finally {
@@ -96,42 +115,49 @@ export default function AdminDashboard() {
   const fetchStats = async () => {
     try {
       const response = await fetch("/api/admin/stats");
-      if (response.ok) {
-        const data = await response.json();
-        setStats(data.stats);
-      }
+      if (!response.ok) return;
+      const data = await response.json();
+      setStats(data.stats);
     } catch (error) {
       console.error("Failed to fetch stats:", error);
     }
   };
 
-  const filteredPosts = posts.filter(post => {
-    const matchesSearch = post.title.toLowerCase().includes(searchTerm.toLowerCase()) ||
-                         post.excerpt.toLowerCase().includes(searchTerm.toLowerCase());
-    const matchesCategory = filterCategory === "all" || post.category === filterCategory;
-    const matchesStatus = filterStatus === "all" || 
-                         (filterStatus === "published" && post.published) ||
-                         (filterStatus === "draft" && !post.published && !post.publish_at) ||
-                         (filterStatus === "scheduled" && post.publish_at);
-    
+  const filteredPosts = posts.filter((post) => {
+    const matchesSearch =
+      post.title.toLowerCase().includes(searchTerm.toLowerCase()) ||
+      post.excerpt.toLowerCase().includes(searchTerm.toLowerCase());
+    const matchesCategory =
+      filterCategory === "all" || post.category === filterCategory;
+    const matchesStatus =
+      filterStatus === "all" ||
+      (filterStatus === "published" && post.published) ||
+      (filterStatus === "draft" && !post.published && !post.publish_at) ||
+      (filterStatus === "scheduled" && post.publish_at);
+
     return matchesSearch && matchesCategory && matchesStatus;
   });
 
-  const categories = ["all", ...Array.from(new Set(posts.map(post => post.category)))];
+  const categories = [
+    "all",
+    ...Array.from(new Set(posts.map((post) => post.category))),
+  ];
 
   if (status === "loading" || loading) {
     return (
       <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex items-center justify-center">
         <div className="text-center">
           <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-indigo-600 mx-auto"></div>
-          <p className="mt-4 text-gray-600 dark:text-gray-400">Loading admin dashboard...</p>
+          <p className="mt-4 text-gray-600 dark:text-gray-400">
+            Loading admin dashboard...
+          </p>
         </div>
       </div>
     );
   }
 
   return (
-    <div className={`min-h-screen ${darkMode ? 'dark' : ''}`}>
+    <div className={`min-h-screen ${darkMode ? "dark" : ""}`}>
       <div className="bg-white dark:bg-gray-900 min-h-screen">
         {/* Header */}
         <header className="bg-white dark:bg-gray-800 shadow-sm border-b border-gray-200 dark:border-gray-700">
@@ -264,13 +290,13 @@ export default function AdminDashboard() {
                   />
                 </div>
               </div>
-              
+
               <select
                 value={filterCategory}
                 onChange={(e) => setFilterCategory(e.target.value)}
                 className="px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
               >
-                {categories.map(category => (
+                {categories.map((category) => (
                   <option key={category} value={category}>
                     {category === "all" ? "All Categories" : category}
                   </option>
@@ -304,14 +330,20 @@ export default function AdminDashboard() {
                           <p className="text-sm font-medium text-indigo-600 dark:text-indigo-400 truncate">
                             {post.category}
                           </p>
-                          <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
-                            post.published 
-                              ? 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200'
+                          <span
+                            className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
+                              post.published
+                                ? "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200"
+                                : post.publish_at
+                                  ? "bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200"
+                                  : "bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-200"
+                            }`}
+                          >
+                            {post.published
+                              ? "Published"
                               : post.publish_at
-                              ? 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200'
-                              : 'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-200'
-                          }`}>
-                            {post.published ? 'Published' : post.publish_at ? 'Scheduled' : 'Draft'}
+                                ? "Scheduled"
+                                : "Draft"}
                           </span>
                         </div>
                         <div className="mt-2">
@@ -323,12 +355,17 @@ export default function AdminDashboard() {
                           </p>
                         </div>
                         <div className="mt-2 flex items-center space-x-4 text-sm text-gray-500 dark:text-gray-400">
-                          <span>{new Date(post.created_at).toLocaleDateString()}</span>
+                          <span>
+                            {new Date(post.created_at).toLocaleDateString()}
+                          </span>
                           <span>{post.views} views</span>
                           <span>{post.likes} likes</span>
                           <div className="flex space-x-1">
-                            {post.tags.slice(0, 3).map((tag, index) => (
-                              <span key={index} className="bg-gray-100 dark:bg-gray-700 px-2 py-1 rounded text-xs">
+                            {post.tags.slice(0, 3).map((tag) => (
+                              <span
+                                key={tag}
+                                className="bg-gray-100 dark:bg-gray-700 px-2 py-1 rounded text-xs"
+                              >
                                 {tag}
                               </span>
                             ))}
@@ -343,7 +380,9 @@ export default function AdminDashboard() {
                           <Eye className="h-4 w-4" />
                         </button>
                         <button
-                          onClick={() => router.push(`/admin/posts/${post.id}/edit`)}
+                          onClick={() =>
+                            router.push(`/admin/posts/${post.id}/edit`)
+                          }
                           className="p-2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
                         >
                           <Edit className="h-4 w-4" />
@@ -360,11 +399,13 @@ export default function AdminDashboard() {
                 </li>
               ))}
             </ul>
-            
+
             {filteredPosts.length === 0 && (
               <div className="text-center py-12">
                 <FileText className="mx-auto h-12 w-12 text-gray-400" />
-                <h3 className="mt-2 text-sm font-medium text-gray-900 dark:text-white">No posts found</h3>
+                <h3 className="mt-2 text-sm font-medium text-gray-900 dark:text-white">
+                  No posts found
+                </h3>
                 <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
                   Get started by generating some content.
                 </p>
@@ -387,18 +428,18 @@ export default function AdminDashboard() {
 
   async function handleDeletePost(postId: string) {
     if (!confirm("Are you sure you want to delete this post?")) return;
-    
+
     try {
       const response = await fetch(`/api/admin/posts/${postId}`, {
         method: "DELETE",
       });
-      
+
       if (response.ok) {
-        setPosts(posts.filter(post => post.id !== postId));
+        setPosts(posts.filter((post) => post.id !== postId));
         fetchStats();
       }
     } catch (error) {
       console.error("Failed to delete post:", error);
     }
   }
-} 
+}


### PR DESCRIPTION
## Summary
- check admin before fetching data
- store dark mode preference in localStorage
- handle fetch errors gracefully
- use tag text as key when listing post tags

## Testing
- `npx prettier --write app/admin/page.tsx`
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e0c55c5008332b5c6f465fbfced81