### PR TITLE
Load categories dynamically from supabase

### DIFF
--- a/app/admin/generate/page.tsx
+++ b/app/admin/generate/page.tsx
@@ -5,21 +5,6 @@ import { useRouter, usePathname } from "next/navigation";
 import { useEffect, useState } from "react";
 import { ArrowLeft, Sparkles, Eye, Edit, Save, RotateCcw } from "lucide-react";
 
-const CATEGORIES = [
-  "Space News",
-  "Astronomy",
-  "Astrophysics",
-  "Cosmology",
-  "Planetary Science",
-  "Space Technology",
-  "Space Exploration",
-  "Exoplanets",
-  "Black Holes",
-  "Galaxies",
-  "Solar System",
-  "Space Missions",
-];
-
 interface GeneratedContent {
   title: string;
   content: string;
@@ -42,6 +27,7 @@ export default function GenerateContent() {
   const [saving, setSaving] = useState(false);
   const [generationError, setGenerationError] = useState<string | null>(null);
   const [highlightCategory, setHighlightCategory] = useState(false);
+  const [availableCategories, setAvailableCategories] = useState<string[]>([]);
 
   // Consider persisting `category` and `customPrompt` across reloads using
   // localStorage or URL search params.
@@ -58,6 +44,22 @@ export default function GenerateContent() {
       checkAdminStatus();
     }
   }, [session, status, router]);
+
+  useEffect(() => {
+    if (!session) return;
+
+    const fetchCategories = async () => {
+      try {
+        const res = await fetch("/api/categories");
+        const data = await res.json();
+        setAvailableCategories(data.categories);
+      } catch (err) {
+        console.error("Failed to load categories", err);
+      }
+    };
+
+    fetchCategories();
+  }, [session]);
 
   const checkAdminStatus = async () => {
     try {
@@ -207,7 +209,7 @@ export default function GenerateContent() {
                   className={`w-full px-3 py-2 border ${highlightCategory ? "border-red-500" : "border-gray-300"} rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500`}
                 >
                   <option value="">Select a category</option>
-                  {CATEGORIES.map((cat) => (
+                  {availableCategories.map((cat) => (
                     <option key={cat} value={cat}>
                       {cat}
                     </option>

--- a/app/api/admin/generate-content/route.ts
+++ b/app/api/admin/generate-content/route.ts
@@ -41,16 +41,6 @@ const openai = new OpenAI({
   apiKey: process.env.OPENAI_API_KEY,
 });
 
-// Categories for content generation
-const CATEGORIES = [
-  "Space News",
-  "Astronomy",
-  "Astrophysics",
-  "Cosmology",
-  "Planetary Science",
-  "Space Technology",
-  "Space Exploration"
-];
 
 // Check for duplicate topics
 async function checkDuplicateTopics(title: string): Promise<boolean> {
@@ -137,7 +127,12 @@ export async function POST(request: NextRequest) {
 
     const { category, customPrompt } = await request.json();
 
-    if (!category || !CATEGORIES.includes(category)) {
+    const { data: categoriesData } = await supabase
+      .from("categories")
+      .select("name");
+
+    const categoryNames = categoriesData?.map(c => c.name);
+    if (!category || !categoryNames?.includes(category)) {
       return NextResponse.json({ error: "Invalid category" }, { status: 400 });
     }
 

--- a/app/api/categories/route.ts
+++ b/app/api/categories/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@supabase/supabase-js";
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!
+);
+
+export async function GET() {
+  const { data, error } = await supabase
+    .from("categories")
+    .select("name");
+
+  if (error) {
+    return NextResponse.json({ error: "Failed to fetch categories" }, { status: 500 });
+  }
+
+  return NextResponse.json({ categories: data?.map((c: any) => c.name) || [] });
+}


### PR DESCRIPTION
## Summary
- fetch categories from server on `GenerateContent` page
- provide `/api/categories` endpoint
- validate categories dynamically when generating content

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e11dc93708332b1ebdf3f01df01d9