### PR TITLE
Improve insights pages

### DIFF
--- a/app/insights/[slug]/page.tsx
+++ b/app/insights/[slug]/page.tsx
@@ -1,28 +1,25 @@
 // app/insights/[slug]/page.tsx
 
 import { Metadata } from "next";
+import { notFound } from "next/navigation";
 import { fetchPostBySlug, fetchPosts } from "../../../lib/posts";
+import { LOGO_URL } from "../../../lib/assets";
 
-interface Post {
-  title: string;
-  excerpt?: string | null;
-  image_url?: string | null;
-  body?: string | null;
-  published_at?: string | null;
-  authorName?: string | null;
-  authorImage?: string | null;
-}
 
 // Generate the list of slugs at build time so Next.js
 // can properly type the `params` prop for this route
 export async function generateStaticParams() {
-  const posts = await fetchPosts(0, 100);
-  return posts.map((post) => ({ slug: post.slug }));
+  try {
+    const posts = await fetchPosts(0, 100);
+    return posts.map((post) => ({ slug: post.slug }));
+  } catch (error) {
+    console.error('Error generating static params for posts:', error);
+    return [];
+  }
 }
 
-export async function generateMetadata({ params }: { params: Promise<{ slug: string }> }): Promise<Metadata> {
-  const { slug } = await params;
-  const post = await fetchPostBySlug(slug);
+export async function generateMetadata({ params }: { params: { slug: string } }): Promise<Metadata> {
+  const post = await fetchPostBySlug(params.slug);
   if (!post) return { title: "Post not found" };
   return {
     title: post.title,
@@ -32,13 +29,14 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
 
 
 
-export default async function PostPage({ params }: { params: Promise<{ slug: string }> }) {
-  const { slug } = await params;
-  const post = await fetchPostBySlug(slug);
+export default async function PostPage({ params }: { params: { slug: string } }) {
+  const post = await fetchPostBySlug(params.slug);
 
   if (!post) {
-    return <p className="text-center py-20">Post not found.</p>;
+    notFound();
   }
+
+  const authorImage = post.authorImage || LOGO_URL;
 
   return (
     <article className="prose prose-invert mx-auto py-10 px-4">
@@ -48,26 +46,26 @@ export default async function PostPage({ params }: { params: Promise<{ slug: str
         <img
           src={post.image_url}
           alt={post.title}
-          className="rounded-lg my-6 w-full"
+          className="rounded-lg my-6 w-full h-auto object-cover"
         />
       )}
 
       <div dangerouslySetInnerHTML={{ __html: post.body || '' }} />
 
       <footer className="mt-12 flex items-center space-x-4 text-sm text-gray-400">
-        {post.authorImage && (
+        {authorImage && (
           <img
-            src={post.authorImage}
+            src={authorImage}
             width={50}
             height={50}
-            alt={post.authorName ?? ''}
+            alt={post.authorName ?? 'Author avatar'}
             className="rounded-full"
           />
         )}
-        <span>
-          {post.authorName}
-          {post.published_at && ` • ${new Date(post.published_at).toLocaleDateString()}`}
-        </span>
+        {post.authorName && <span>{post.authorName}</span>}
+        {post.published_at && (
+          <span className="ml-1">• {new Date(post.published_at).toLocaleDateString()}</span>
+        )}
       </footer>
     </article>
   );

--- a/app/insights/page/[page]/page.tsx
+++ b/app/insights/page/[page]/page.tsx
@@ -1,24 +1,36 @@
 import PostCard from "../../../../components/PostCard";
 import { fetchPosts } from "../../../../lib/posts";
+import { notFound } from "next/navigation";
 
 export const revalidate = 60;
 
-export default async function InsightsPage({ params }: { params: Promise<{ page: string }> }) {
-  const { page: pageParam } = await params;
-  const page = parseInt(pageParam, 10) || 1;
+export default async function InsightsPage({ params }: { params: { page: string } }) {
+  const pageNum = Number(params.page);
+  if (!Number.isInteger(pageNum) || pageNum < 1) {
+    notFound();
+  }
+  const page = pageNum;
   const POSTS_PER_PAGE = 6;
   const start = (page - 1) * POSTS_PER_PAGE;
   const end = start + POSTS_PER_PAGE - 1;
   const posts = await fetchPosts(start, end);
 
+  if (!posts.length && page !== 1) {
+    notFound();
+  }
+
   return (
     <section className="space-y-4">
       <h1 className="text-3xl font-orbitron">Orbital Insights - Page {page}</h1>
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-        {posts.map((post) => (
-          <PostCard key={post.id} post={post} />
-        ))}
-      </div>
+      {posts.length ? (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          {posts.map((post) => (
+            <PostCard key={post.id} post={post} />
+          ))}
+        </div>
+      ) : (
+        <p className="py-10 text-center text-spacex-gray">No posts found.</p>
+      )}
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- improve `/insights/page/[page]` to validate params and show fallback UI
- harden `/insights/[slug]` with proper param types and notFound handling
- enhance author and image rendering in post pages

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685e19af3f5c83329d74774b0137511d