### PR TITLE
Fix params typing in insights page

### DIFF
--- a/app/insights/[slug]/page.tsx
+++ b/app/insights/[slug]/page.tsx
@@ -19,7 +19,8 @@ export async function generateStaticParams() {
 }
 
 export async function generateMetadata({ params }: { params: { slug: string } }): Promise<Metadata> {
-  const post = await fetchPostBySlug(params.slug);
+  const { slug } = params;
+  const post = await fetchPostBySlug(slug);
   if (!post) return { title: "Post not found" };
   return {
     title: post.title,


### PR DESCRIPTION
## Summary
- correct param destructuring in insights page metadata function

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e1c7e5f6c83329213b52b93ef1a91