### PR TITLE
Fix params typing in insights page

### DIFF
--- a/app/insights/[slug]/page.tsx
+++ b/app/insights/[slug]/page.tsx
@@ -5,7 +5,7 @@ import { fetchPostBySlug, fetchPosts } from "../../../lib/posts";
 
 // Generate the list of slugs at build time so Next.js
 // can properly type the `params` prop for this route
-export async function generateStaticParams() {
+export async function generateStaticParams(): Promise<{ slug: string }[]> {
   try {
     const posts = await fetchPosts(0, 100);
     return posts.map((post) => ({ slug: post.slug }));


### PR DESCRIPTION
## Summary
- correct typing of `generateStaticParams` so `params` isn't treated as a `Promise`
- maintain synchronous access to params in `PostPage`

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e234ace6c833299f39c5188055516