### PR TITLE
Fix insights slug page typing

### DIFF
--- a/app/insights/[slug]/page.tsx
+++ b/app/insights/[slug]/page.tsx
@@ -33,7 +33,7 @@ export default async function PostPage({
   params,
 }: {
   params: { slug: string };
-}) {
+}): Promise<JSX.Element> {
   const { slug } = params;
   const post = await fetchPostBySlug(slug);
 


### PR DESCRIPTION
## Summary
- correct typing for `params` usage on insights slug page

## Testing
- `npx prettier --write app/insights/[slug]/page.tsx`

------
https://chatgpt.com/codex/tasks/task_e_685e256bc3c48332b931fa547e4c6fe4