### PR TITLE
Fix searchParams props types

### DIFF
--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -3,11 +3,11 @@ import PostList from "../../components/PostList";
 import { Search } from "lucide-react";
 
 interface SearchPageProps {
-  searchParams: Promise<{ q?: string }>;
+  searchParams: { q?: string };
 }
 
 export default async function SearchPage({ searchParams }: SearchPageProps) {
-  const { q: queryParam } = await searchParams;
+  const { q: queryParam } = searchParams;
   const query = queryParam || "";
   const allPosts = (await fetchPosts(0, 100)) ?? [];
   

--- a/app/set-password/page.tsx
+++ b/app/set-password/page.tsx
@@ -7,7 +7,7 @@ import InvalidTokenNotice from "../../components/InvalidTokenNotice";
 import { createClient } from "@supabase/supabase-js";
 
 interface SetPasswordPageProps {
-  searchParams: Promise<{ token?: string }>;
+  searchParams: { token?: string };
 }
 
 export default async function SetPasswordPage({
@@ -18,7 +18,7 @@ export default async function SetPasswordPage({
     secret: process.env.NEXTAUTH_SECRET,
   });
 
-  const { token } = await searchParams;
+  const { token } = searchParams;
 
   if (session?.user?.email) {
     return (


### PR DESCRIPTION
## Summary
- update `SearchPageProps` and `SetPasswordPageProps` to use synchronous `searchParams`
- adjust usages accordingly

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e2dbdfe0c8332b78386145b93e774