### PR TITLE
Fix PostPage props typing

### DIFF
--- a/app/insights/[slug]/page.tsx
+++ b/app/insights/[slug]/page.tsx
@@ -1,4 +1,3 @@
-// app/insights/[slug]/page.tsx
 import { Metadata } from "next";
 import { fetchPostBySlug, fetchPosts } from "../../../lib/posts";
 
@@ -7,7 +6,7 @@ export async function generateStaticParams(): Promise<{ slug: string }[]> {
     const posts = await fetchPosts(0, 100);
     return posts.map((post) => ({ slug: post.slug }));
   } catch (error) {
-    console.error("Error generating static params:", error);
+    console.error("Error generating static params for posts:", error);
     return [];
   }
 }
@@ -17,19 +16,24 @@ export async function generateMetadata({
 }: {
   params: { slug: string };
 }): Promise<Metadata> {
-  const post = await fetchPostBySlug(params.slug);
+  const { slug } = params;
+  const post = await fetchPostBySlug(slug);
+  if (!post) return { title: "Post not found" };
   return {
-    title: post?.title || "Post not found",
-    description: post?.excerpt || undefined,
+    title: post.title,
+    description: post.excerpt || undefined,
   };
 }
 
-export default async function Page({
-  params,
-}: {
-  params: { slug: string };
-}): Promise<JSX.Element> {
-  const post = await fetchPostBySlug(params.slug);
+type PostPageProps = {
+  params: {
+    slug: string;
+  };
+};
+
+export default async function PostPage({ params }: PostPageProps) {
+  const { slug } = params;
+  const post = await fetchPostBySlug(slug);
 
   if (!post) {
     return <p className="text-center py-20">Post not found.</p>;
@@ -38,6 +42,7 @@ export default async function Page({
   return (
     <article className="prose prose-invert mx-auto py-10 px-4">
       <h1>{post.title}</h1>
+
       {post.image_url && (
         <img
           src={post.image_url}
@@ -45,7 +50,9 @@ export default async function Page({
           className="rounded-lg my-6 w-full"
         />
       )}
+
       <div dangerouslySetInnerHTML={{ __html: post.body || "" }} />
+
       <footer className="mt-12 flex items-center space-x-4 text-sm text-gray-400">
         {post.authorImage && (
           <img


### PR DESCRIPTION
## Summary
- fix PostPage type error by using a local `PostPageProps` type

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e30bcef4c8332b731142ba96c335a