### PR TITLE
Fix PageProps typing issue

### DIFF
--- a/app/insights/[slug]/page.tsx
+++ b/app/insights/[slug]/page.tsx
@@ -28,7 +28,7 @@ export default async function Page({
   params,
 }: {
   params: { slug: string };
-}): Promise<JSX.Element> {
+}) {
   const post = await fetchPostBySlug(params.slug);
 
   if (!post) {


### PR DESCRIPTION
## Summary
- remove the explicit `Promise<JSX.Element>` return type from the dynamic post page

## Testing
- `npx tsc --noEmit` *(fails: command not found or missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685e31b369e08332a305964863f2a553