### PR TITLE
Fix PageProps typing for insights slug page

### DIFF
--- a/app/insights/[slug]/page.tsx
+++ b/app/insights/[slug]/page.tsx
@@ -1,5 +1,5 @@
 // app/insights/[slug]/page.tsx
-import { Metadata } from "next";
+import { Metadata, type PageProps } from "next";
 import { fetchPostBySlug, fetchPosts } from "../../../lib/posts";
 
 export async function generateStaticParams(): Promise<{ slug: string }[]> {
@@ -14,9 +14,7 @@ export async function generateStaticParams(): Promise<{ slug: string }[]> {
 
 export async function generateMetadata({
   params,
-}: {
-  params: { slug: string };
-}): Promise<Metadata> {
+}: PageProps<{ slug: string }>): Promise<Metadata> {
   const post = await fetchPostBySlug(params.slug);
   return {
     title: post?.title || "Post not found",
@@ -26,9 +24,7 @@ export async function generateMetadata({
 
 export default async function Page({
   params,
-}: {
-  params: { slug: string };
-}): Promise<JSX.Element> {
+}: PageProps<{ slug: string }>): Promise<JSX.Element> {
   const post = await fetchPostBySlug(params.slug);
 
   if (!post) {


### PR DESCRIPTION
## Summary
- import `PageProps` from Next.js
- use `PageProps` for parameters in the insights page

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e344fd55483328e42da306e82ab34