### PR TITLE
Fix type error in page

### DIFF
--- a/app/insights/page/[page]/page.tsx
+++ b/app/insights/page/[page]/page.tsx
@@ -1,10 +1,13 @@
 import PostCard from "../../../../components/PostCard";
 import { fetchPosts } from "../../../../lib/posts";
 import { notFound } from "next/navigation";
+import type { PageProps } from "next";
 
 export const revalidate = 60;
 
-export default async function InsightsPage({ params }: { params: { page: string } }) {
+export default async function InsightsPage({
+  params,
+}: PageProps<{ page: string }>) {
   const pageNum = Number(params.page);
   if (!Number.isInteger(pageNum) || pageNum < 1) {
     notFound();


### PR DESCRIPTION
## Summary
- import `PageProps` in the paginated insights page
- update type signature for `InsightsPage` to use `PageProps<{ page: string }>`

## Testing
- `npm install --legacy-peer-deps` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e367eef2483328ab946403fee8f22