### PR TITLE
Fix type error in set password page

### DIFF
--- a/app/set-password/page.tsx
+++ b/app/set-password/page.tsx
@@ -5,14 +5,15 @@ import { authOptions } from "../../lib/auth-options";
 import SetPasswordForm from "../../components/SetPasswordForm";
 import InvalidTokenNotice from "../../components/InvalidTokenNotice";
 import { createClient } from "@supabase/supabase-js";
+import type { PageProps } from "next";
 
-interface SetPasswordPageProps {
-  searchParams: { token?: string };
+export async function generateStaticParams(): Promise<Record<string, never>[]> {
+  return [];
 }
 
 export default async function SetPasswordPage({
   searchParams,
-}: SetPasswordPageProps) {
+}: PageProps<{}, { token?: string }>) {
   const session = await getServerSession({
     ...authOptions,
     secret: process.env.NEXTAUTH_SECRET,


### PR DESCRIPTION
## Summary
- prevent Next.js from typing `searchParams` as a Promise
- use `PageProps` helper type

## Testing
- `npm install --legacy-peer-deps` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eb3956d508332acdda789f09cffc5