### PR TITLE
Fix PageProps format

### DIFF
--- a/types/page-props.d.ts
+++ b/types/page-props.d.ts
@@ -1,6 +1,9 @@
 export interface PageProps<
   Params extends Record<string, string> = {},
-  SearchParams extends Record<string, string | string[] | undefined> = {}
+  SearchParams extends Record<
+    string,
+    string | string[] | undefined
+  > = {}
 > {
   params: Params;
   searchParams: SearchParams;


### PR DESCRIPTION
## Summary
- clarify generics in `PageProps` type

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eb5d853788332b8eef01e6e6b3196