### PR TITLE
Fix PageProps type usage

### DIFF
--- a/app/insights/[slug]/page.tsx
+++ b/app/insights/[slug]/page.tsx
@@ -1,5 +1,6 @@
 // app/insights/[slug]/page.tsx
-import { Metadata, type PageProps } from "next";
+import type { Metadata } from "next";
+import type { PageProps } from "@/types/page-props";
 import { fetchPostBySlug, fetchPosts } from "../../../lib/posts";
 
 export async function generateStaticParams(): Promise<{ slug: string }[]> {

--- a/app/insights/page/[page]/page.tsx
+++ b/app/insights/page/[page]/page.tsx
@@ -1,7 +1,7 @@
 import PostCard from "../../../../components/PostCard";
 import { fetchPosts } from "../../../../lib/posts";
 import { notFound } from "next/navigation";
-import type { PageProps } from "next";
+import type { PageProps } from "@/types/page-props";
 
 // Explicitly export an empty `generateStaticParams` to signal that this
 // route is fully dynamic. This keeps Next.js from typing the `params`

--- a/app/legal/[slug]/page.tsx
+++ b/app/legal/[slug]/page.tsx
@@ -1,6 +1,7 @@
 // app/legal/[slug]/page.tsx
 import { fetchLegalPage, fetchLegalPageSlugs } from '../../../lib/posts';
-import { Metadata, type PageProps } from 'next';
+import type { Metadata } from 'next';
+import type { PageProps } from '@/types/page-props';
 
 // 1) Generate all slugs at build time (fetching the string array)
 export async function generateStaticParams(): Promise<{ slug: string }[]> {

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -1,7 +1,7 @@
 import { fetchPosts } from "../../lib/posts";
 import PostList from "../../components/PostList";
 import { Search } from "lucide-react";
-import type { PageProps } from "next";
+import type { PageProps } from "@/types/page-props";
 
 // Export an empty `generateStaticParams` so Next.js does not treat the
 // `searchParams` prop as a Promise. This keeps the `PageProps` helper type

--- a/app/set-password/page.tsx
+++ b/app/set-password/page.tsx
@@ -5,7 +5,7 @@ import { authOptions } from "../../lib/auth-options";
 import SetPasswordForm from "../../components/SetPasswordForm";
 import InvalidTokenNotice from "../../components/InvalidTokenNotice";
 import { createClient } from "@supabase/supabase-js";
-import type { PageProps } from "next";
+import type { PageProps } from "@/types/page-props";
 
 export async function generateStaticParams(): Promise<Record<string, never>[]> {
   return [];

--- a/types/page-props.d.ts
+++ b/types/page-props.d.ts
@@ -1,0 +1,10 @@
+export interface PageProps<
+  Params extends Record<string, string> = {},
+  SearchParams extends Record<
+    string,
+    string | string[] | undefined
+  > = {}
+> {
+  params: Params;
+  searchParams: SearchParams;
+}


### PR DESCRIPTION
## Summary
- restore custom `PageProps` type
- update pages to import the custom helper

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eb9744c748332ba7ab669d1c8788b