### PR TITLE
Fix RouteProps naming conflict in Next.js 15

### DIFF
--- a/app/insights/page/[page]/page.tsx
+++ b/app/insights/page/[page]/page.tsx
@@ -1,11 +1,11 @@
 import PostCard from "../../../../components/PostCard";
 import { fetchPosts } from "../../../../lib/posts";
 import { notFound } from "next/navigation";
-import type { PageProps } from "@/types/page-props";
+import type { RouteProps } from "@/types/route-props";
 
 // Explicitly export an empty `generateStaticParams` to signal that this
 // route is fully dynamic. This keeps Next.js from typing the `params`
-// argument as a Promise and allows us to use the `PageProps` helper type
+// argument as a Promise and allows us to use the `RouteProps` helper type
 // without build errors.
 
 export async function generateStaticParams(): Promise<{ page: string }[]> {
@@ -16,7 +16,7 @@ export const revalidate = 60;
 
 export default async function InsightsPage({
   params,
-}: PageProps<{ page: string }>) {
+}: RouteProps<{ page: string }>) {
   const pageNum = Number(params.page);
   if (!Number.isInteger(pageNum) || pageNum < 1) {
     notFound();

--- a/app/legal/[slug]/page.tsx
+++ b/app/legal/[slug]/page.tsx
@@ -1,7 +1,7 @@
 // app/legal/[slug]/page.tsx
 import { fetchLegalPage, fetchLegalPageSlugs } from '../../../lib/posts';
 import type { Metadata } from 'next';
-import type { PageProps } from '@/types/page-props';
+import type { RouteProps } from '@/types/route-props';
 
 // 1) Generate all slugs at build time (fetching the string array)
 export async function generateStaticParams(): Promise<{ slug: string }[]> {
@@ -15,7 +15,7 @@ export async function generateStaticParams(): Promise<{ slug: string }[]> {
 }
 
 // 2) Per-page metadata
-export async function generateMetadata({ params }: PageProps<{ slug: string }>): Promise<Metadata> {
+export async function generateMetadata({ params }: RouteProps<{ slug: string }>): Promise<Metadata> {
   const { slug } = params;
   const page = await fetchLegalPage(slug);
   return {
@@ -25,7 +25,7 @@ export async function generateMetadata({ params }: PageProps<{ slug: string }>):
 }
 
 // 3) Page component
-export default async function LegalPage({ params }: PageProps<{ slug: string }>): Promise<JSX.Element> {
+export default async function LegalPage({ params }: RouteProps<{ slug: string }>): Promise<JSX.Element> {
   const { slug } = params;
   const page = await fetchLegalPage(slug);
 

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -1,10 +1,10 @@
 import { fetchPosts } from "../../lib/posts";
 import PostList from "../../components/PostList";
 import { Search } from "lucide-react";
-import type { PageProps } from "@/types/page-props";
+import type { RouteProps } from "@/types/route-props";
 
 // Export an empty `generateStaticParams` so Next.js does not treat the
-// `searchParams` prop as a Promise. This keeps the `PageProps` helper type
+// `searchParams` prop as a Promise. This keeps the `RouteProps` helper type
 // usable without build errors.
 export async function generateStaticParams(): Promise<Record<string, never>[]> {
   return [];
@@ -12,7 +12,7 @@ export async function generateStaticParams(): Promise<Record<string, never>[]> {
 
 export default async function SearchPage({
   searchParams,
-}: PageProps<{}, { q?: string }>) {
+}: RouteProps<{}, { q?: string }>) {
   const { q: queryParam } = searchParams;
   const query = queryParam || "";
   const allPosts = (await fetchPosts(0, 100)) ?? [];

--- a/app/set-password/page.tsx
+++ b/app/set-password/page.tsx
@@ -5,7 +5,7 @@ import { authOptions } from "../../lib/auth-options";
 import SetPasswordForm from "../../components/SetPasswordForm";
 import InvalidTokenNotice from "../../components/InvalidTokenNotice";
 import { createClient } from "@supabase/supabase-js";
-import type { PageProps } from "@/types/page-props";
+import type { RouteProps } from "@/types/route-props";
 
 export async function generateStaticParams(): Promise<Record<string, never>[]> {
   return [];
@@ -13,7 +13,7 @@ export async function generateStaticParams(): Promise<Record<string, never>[]> {
 
 export default async function SetPasswordPage({
   searchParams,
-}: PageProps<{}, { token?: string }>) {
+}: RouteProps<{}, { token?: string }>) {
   const session = await getServerSession({
     ...authOptions,
     secret: process.env.NEXTAUTH_SECRET,

--- a/types/route-props.d.ts
+++ b/types/route-props.d.ts
@@ -1,4 +1,4 @@
-export interface PageProps<
+export interface RouteProps<
   Params extends Record<string, string> = {},
   SearchParams extends Record<
     string,


### PR DESCRIPTION
## Summary
- rename `PageProps` helper to `RouteProps`
- update imports and usages across the codebase

## Testing
- `npm run build` *(fails: next not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ebf630bc4833291418fb649071de7