### PR TITLE
Fix resend package dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,8 +43,7 @@
     "react-dom": "18.2.0",
     "react-icons": "5.5.0",
     "tailwindcss": "3.4.1",
-    "resend": "^4.6.0",
-    "@resend/node": "^2.1.0"
+    "resend": "^2.1.0"
   },
   "devDependencies": {
     "@mdx-js/loader": "3.1.0",


### PR DESCRIPTION
## Summary
- fix password reset package to use `resend` instead of `@resend/node`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ef0eb39f88332a49f94bdfb2c8084