### PR TITLE
Update Resend import

### DIFF
--- a/app/api/request-password-reset/route.ts
+++ b/app/api/request-password-reset/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { createClient } from "@supabase/supabase-js";
-import { Resend } from "@resend/node";
+import { Resend } from "resend";
 import crypto from "crypto";
 
 const supabase = createClient(


### PR DESCRIPTION
## Summary
- replace deprecated `@resend/node` import with `resend` package

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_685ef38559b8833287a827276c97721b