### PR TITLE
Fix Resend email options

### DIFF
--- a/app/api/request-password-reset/route.ts
+++ b/app/api/request-password-reset/route.ts
@@ -65,7 +65,6 @@ export async function POST(req: Request) {
           <p><a href="${link}">${link}</a></p>
         `,
         text: `Reset your password using this link: ${link}`,
-        trackLinks: false,
       });
     } catch (err) {
       console.error("request-password-reset email error:", err);


### PR DESCRIPTION
## Summary
- remove unsupported `trackLinks` option when sending password reset emails

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685f06eb5f588332ae5e49d1840dc1af