### PR TITLE
Implement password reset email flow

### DIFF
--- a/app/api/request-password-reset/route.ts
+++ b/app/api/request-password-reset/route.ts
@@ -1,40 +1,68 @@
 import { NextResponse } from "next/server";
-import { Resend } from "resend";
+import { createClient } from "@supabase/supabase-js";
+import { Resend } from "@resend/client";
+import { v4 as uuid } from "uuid";
 
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!,
+);
 const resend = new Resend(process.env.RESEND_API_KEY!);
 
 export async function POST(req: Request) {
-  try {
-    const { email, token } = await req.json();
+  const { email } = await req.json().catch(() => ({}));
 
-    if (!email || !token || typeof email !== "string" || typeof token !== "string") {
-      return NextResponse.json(
-        { error: "Missing email or token" },
-        { status: 400 },
-      );
+  if (!email || typeof email !== "string") {
+    return NextResponse.json({ error: "Missing email" }, { status: 400 });
+  }
+
+  try {
+    const { data: user, error } = await supabase
+      .from("users")
+      .select("id")
+      .eq("email", email.toLowerCase())
+      .maybeSingle();
+
+    if (error) {
+      console.error("request-password-reset lookup error:", error);
+      return NextResponse.json({ error: "Database error" }, { status: 500 });
+    }
+
+    if (!user) {
+      return NextResponse.json({ success: true });
+    }
+
+    const token = uuid();
+
+    const { error: insertErr } = await supabase
+      .from("password_reset_tokens")
+      .insert({
+        id: token,
+        user_id: user.id,
+        created_at: new Date().toISOString(),
+      });
+
+    if (insertErr) {
+      console.error("request-password-reset insert error:", insertErr);
+      return NextResponse.json({ error: "Database error" }, { status: 500 });
     }
 
     const link = `https://interstellarnerd.com/set-password?token=${token}`;
 
-    try {
-      await resend.emails.send({
-        from: "Interstellar Nerd <noreply@interstellarnerd.com>",
-        to: email,
-        subject: "Reset Your Password",
-        html: `<p>Click <a href="${link}">here</a> to reset your password.</p>`,
-        text: `Reset your password using this link: ${link}`,
-      });
-    } catch (err) {
-      console.error("request-password-reset email error:", err);
-      return NextResponse.json(
-        { error: "Failed to send email" },
-        { status: 500 },
-      );
-    }
+    await resend.emails.send({
+      from: "Interstellar Nerd <noreply@interstellarnerd.com>",
+      to: email,
+      subject: "Reset Your Password",
+      html: `<p>Click <a href="${link}">here</a> to reset your password.</p>`,
+      text: `Reset your password using this link: ${link}`,
+    });
 
     return NextResponse.json({ success: true });
   } catch (err) {
-    console.error("request-password-reset unexpected error:", err);
-    return NextResponse.json({ error: "Invalid request" }, { status: 400 });
+    console.error("request-password-reset error:", err);
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : "Server error" },
+      { status: 500 },
+    );
   }
 }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,9 @@
     "react-dom": "18.2.0",
     "react-icons": "5.5.0",
     "tailwindcss": "3.4.1",
-    "resend": "^2.1.0"
+    "resend": "^2.1.0",
+    "@resend/client": "^2.1.0",
+    "uuid": "^9.0.0"
   },
   "devDependencies": {
     "@mdx-js/loader": "3.1.0",


### PR DESCRIPTION
## Summary
- rewrite password reset API route to generate tokens, save them in Supabase, and send via Resend
- add `@resend/client` and `uuid` dependencies

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f0d73bfc083329f8b7b25fd47223d