### PR TITLE
Update verify-reset-token endpoint

### DIFF
--- a/app/api/verify-reset-token/route.ts
+++ b/app/api/verify-reset-token/route.ts
@@ -8,35 +8,44 @@ const supabase = createClient(
 
 export async function POST(req: Request) {
   const { token } = await req.json();
-
   console.log("🔐 Received token:", token);
 
-  if (!token) {
-    console.log("❌ No token provided");
+  if (!token || typeof token !== "string") {
+    console.log("❌ Missing or invalid token");
     return NextResponse.json({ valid: false, reason: "missing_token" }, { status: 400 });
   }
 
   const { data, error } = await supabase
     .from("password_reset_tokens")
     .select("token, user_id, expires_at")
-    .eq("token", token)
+    .eq("token", token.trim())
     .maybeSingle();
 
-  console.log("🧾 Supabase result:", { data, error });
-  console.log("🕒 Current time:", new Date());
+  console.log("🧾 DB response:", { data, error });
+  console.log("🕒 Current time (UTC):", new Date().toISOString());
 
   if (error || !data) {
-    console.log("❌ Token not found");
-    return NextResponse.json({ valid: false, reason: "not_found" }, { status: 401 });
+    console.log("❌ Token not found in database");
+    return NextResponse.json({ valid: false, reason: "not_found" }, { status: 404 });
   }
 
-  const isExpired = new Date(data.expires_at) < new Date();
+  if (!data.expires_at) {
+    console.log("❌ Missing expires_at field");
+    return NextResponse.json({ valid: false, reason: "no_expiry" }, { status: 400 });
+  }
+
+  const now = new Date();
+  const expiry = new Date(data.expires_at);
+  const isExpired = expiry.getTime() < now.getTime();
+
+  console.log("📅 Token expires at:", expiry.toISOString());
+  console.log("⏳ Is expired?", isExpired);
+
   if (isExpired) {
-    console.log("⚠️ Token is expired:", data.expires_at);
+    console.log("⚠️ Token is expired");
     return NextResponse.json({ valid: false, reason: "expired" }, { status: 401 });
   }
 
-  console.log("✅ Token is valid, user_id:", data.user_id);
-
+  console.log("✅ Token is valid for user:", data.user_id);
   return NextResponse.json({ valid: true, user_id: data.user_id });
 }


### PR DESCRIPTION
## Summary
- make `verify-reset-token` API route handle bad input
- log timestamps in UTC and report missing fields

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f318195a48332a8f2e8413d1f6515