### PR TITLE
Fix set-password page SSR issue

### DIFF
--- a/app/set-password/page.tsx
+++ b/app/set-password/page.tsx
@@ -1,5 +1,5 @@
-import dynamic from "next/dynamic";
-const ClientForm = dynamic(() => import("./ClientForm"), { ssr: false });
+"use client";
+import ClientForm from "./ClientForm";
 
 export default function SetPasswordPage() {
   return <ClientForm />;


### PR DESCRIPTION
## Summary
- convert `app/set-password/page.tsx` to a client component so that
  `useSearchParams` can be used safely

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f38b3d1c08332936885165357578f