### PR TITLE
Add username change feature

### DIFF
--- a/app/api/change-username/route.ts
+++ b/app/api/change-username/route.ts
@@ -1,0 +1,71 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { getToken } from "next-auth/jwt";
+import { createClient } from "@supabase/supabase-js";
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!
+);
+
+const USERNAME_REGEX = /^[a-zA-Z0-9_]{3,20}$/;
+const OFFENSIVE = [
+  "admin",
+  "mod",
+  "fuck",
+  "shit",
+  "bitch",
+  "nigger",
+  "slut",
+  "cunt",
+];
+
+export async function POST(req: NextRequest) {
+  const token = await getToken({ req });
+  if (!token?.sub) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const { newUsername } = await req.json();
+    const username = (newUsername || "").trim();
+
+    if (!USERNAME_REGEX.test(username)) {
+      return NextResponse.json({ error: "Invalid username" }, { status: 400 });
+    }
+
+    if (OFFENSIVE.some((w) => username.toLowerCase().includes(w))) {
+      return NextResponse.json({ error: "Offensive term not allowed" }, { status: 400 });
+    }
+
+    const { data: existing, error: fetchErr } = await supabase
+      .from("profiles")
+      .select("id")
+      .eq("username", username)
+      .neq("user_id", token.sub as string)
+      .maybeSingle();
+
+    if (fetchErr) {
+      console.error("Check username error", fetchErr);
+      return NextResponse.json({ error: "Server error" }, { status: 500 });
+    }
+
+    if (existing) {
+      return NextResponse.json({ error: "Username taken" }, { status: 409 });
+    }
+
+    const { error: updateErr } = await supabase
+      .from("profiles")
+      .update({ username })
+      .eq("user_id", token.sub as string);
+
+    if (updateErr) {
+      console.error("Update username error", updateErr);
+      return NextResponse.json({ error: "Failed to update username" }, { status: 500 });
+    }
+
+    return NextResponse.json({ success: true, username });
+  } catch (err) {
+    console.error("Change username route error", err);
+    return NextResponse.json({ error: "Invalid request" }, { status: 400 });
+  }
+}

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -4,6 +4,7 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "../../lib/auth-options";
 import { createClient } from "@supabase/supabase-js";
 import ProfileView from "../../components/ProfileView";
+import ChangeUsernameForm from "../../components/ChangeUsernameForm";
 import crypto from "crypto";
 
 export default async function ProfilePage() {
@@ -67,11 +68,14 @@ export default async function ProfilePage() {
   ]);
 
   return (
-    <ProfileView
-      profile={profile}
-      stats={{ threads: threadCount ?? 0, replies: replyCount ?? 0 }}
-      isOwnProfile={true}
-      user={session.user}
-    />
+    <>
+      <ProfileView
+        profile={profile}
+        stats={{ threads: threadCount ?? 0, replies: replyCount ?? 0 }}
+        isOwnProfile={true}
+        user={session.user}
+      />
+      <ChangeUsernameForm current={profile.username} />
+    </>
   );
 }

--- a/components/ChangeUsernameForm.tsx
+++ b/components/ChangeUsernameForm.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useState } from "react";
+import { toast } from "react-hot-toast";
+import { useSession } from "next-auth/react";
+
+export default function ChangeUsernameForm({ current }: { current: string | null }) {
+  const { update } = useSession();
+  const [username, setUsername] = useState(current ?? "");
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    try {
+      const res = await fetch("/api/change-username", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ newUsername: username }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || "Failed to update username");
+      toast.success("Username updated");
+      await update();
+    } catch (err: any) {
+      toast.error(err.message || "Failed to update username");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4 mt-6 max-w-md">
+      <input
+        type="text"
+        value={username}
+        onChange={(e) => setUsername(e.target.value)}
+        placeholder="New username"
+        className="w-full p-2 rounded text-black"
+      />
+      <button
+        type="submit"
+        disabled={loading}
+        className="bg-neon text-white w-full p-2 rounded disabled:opacity-50"
+      >
+        {loading ? "Updating..." : "Change Username"}
+      </button>
+    </form>
+  );
+}


### PR DESCRIPTION
## Summary
- add secure `/api/change-username` endpoint
- create `ChangeUsernameForm` client component
- include username change form on profile page

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f43bc10c483328824116f450a087e