### PR TITLE
Fix password reset flow

### DIFF
--- a/app/api/set-password/route.ts
+++ b/app/api/set-password/route.ts
@@ -1,6 +1,5 @@
-import { NextResponse, type NextRequest } from "next/server";
-import { getServerSession } from "next-auth";
-import { authOptions } from "../../../lib/auth-options";
+import { NextResponse } from "next/server";
+import { signIn } from "next-auth/react";
 import bcrypt from "bcryptjs";
 import { createClient } from "@supabase/supabase-js";
 
@@ -9,39 +8,72 @@ const supabase = createClient(
   process.env.SUPABASE_SERVICE_ROLE_KEY!
 );
 
-export async function POST(req: NextRequest) {
-  const session = await getServerSession({
-    ...authOptions,
-    secret: process.env.NEXTAUTH_SECRET,
-  });
-
-  if (!session?.user?.id) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
+export async function POST(req: Request) {
   try {
-    const { password } = await req.json();
+    const { token, password } = await req.json().catch(() => ({}));
 
-    if (!password || password.length < 6) {
+    if (!token || typeof token !== "string") {
+      return NextResponse.json({ error: "Missing token" }, { status: 400 });
+    }
+
+    if (!password || typeof password !== "string" || password.length < 6) {
       return NextResponse.json({ error: "Password too short" }, { status: 400 });
+    }
+
+    const { data: tokenRow } = await supabase
+      .from("password_reset_tokens")
+      .select("user_id, expires_at")
+      .eq("token", token)
+      .maybeSingle();
+
+    if (!tokenRow || new Date(tokenRow.expires_at).getTime() < Date.now()) {
+      return NextResponse.json(
+        { error: "Invalid or expired token" },
+        { status: 400 }
+      );
+    }
+
+    const { data: user } = await supabase
+      .from("users")
+      .select("email")
+      .eq("id", tokenRow.user_id)
+      .maybeSingle();
+
+    if (!user?.email) {
+      return NextResponse.json({ error: "User not found" }, { status: 404 });
     }
 
     const hashed = await bcrypt.hash(password, 12);
 
-    const { error } = await supabase
+    const { error: updateErr } = await supabase
       .from("users")
       .update({ hashed_password: hashed })
-      .eq("id", session.user.id);
+      .eq("id", tokenRow.user_id);
 
-    if (error) {
-      console.error("Error updating password:", error);
-      return NextResponse.json({ error: error.message }, { status: 500 });
+    if (updateErr) {
+      console.error("Error updating password:", updateErr);
+      return NextResponse.json(
+        { error: "Failed to update password" },
+        { status: 500 }
+      );
     }
 
+    await supabase.from("password_reset_tokens").delete().eq("token", token);
+
+    const loginRes = await signIn("credentials", {
+      redirect: false,
+      email: user.email,
+      password,
+    });
+
+    if (loginRes?.error) {
+      console.error("Auto-login failed:", loginRes.error);
+      return NextResponse.json({ error: "Login failed" }, { status: 500 });
+    }
 
     return NextResponse.json({ success: true });
   } catch (error) {
     console.error("Error in set-password route:", error);
-    return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+    return NextResponse.json({ error: "Invalid request" }, { status: 400 });
   }
 }


### PR DESCRIPTION
## Summary
- reset password via `/api/set-password`
- validate reset token, update password, sign in user

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f45b6e0a08332808a77944a10578c