### PR TITLE
Password reset improvements

### DIFF
--- a/app/api/set-password/route.ts
+++ b/app/api/set-password/route.ts
@@ -1,5 +1,4 @@
 import { NextResponse } from "next/server";
-import { signIn } from "next-auth/react";
 import bcrypt from "bcryptjs";
 import { createClient } from "@supabase/supabase-js";
 
@@ -60,18 +59,7 @@ export async function POST(req: Request) {
 
     await supabase.from("password_reset_tokens").delete().eq("token", token);
 
-    const loginRes = await signIn("credentials", {
-      redirect: false,
-      email: user.email,
-      password,
-    });
-
-    if (loginRes?.error) {
-      console.error("Auto-login failed:", loginRes.error);
-      return NextResponse.json({ error: "Login failed" }, { status: 500 });
-    }
-
-    return NextResponse.json({ success: true });
+    return NextResponse.json({ success: true, email: user.email });
   } catch (error) {
     console.error("Error in set-password route:", error);
     return NextResponse.json({ error: "Invalid request" }, { status: 400 });

--- a/app/set-password/ClientForm.tsx
+++ b/app/set-password/ClientForm.tsx
@@ -2,6 +2,7 @@
 import { useSearchParams, useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import { toast } from 'react-hot-toast';
+import { signIn } from 'next-auth/react';
 import PasswordInput from '@/components/PasswordInput';
 
 export default function ClientForm() {
@@ -44,9 +45,21 @@ export default function ClientForm() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ token, password })
       });
-      if (!res.ok) throw new Error('Failed');
-      toast.success('Password reset! Redirecting...');
-      router.push('/profile');
+
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || 'Failed');
+
+      toast.success('Password reset! Logging you in...');
+
+      const login = await signIn('credentials', {
+        redirect: false,
+        email: data.email,
+        password
+      });
+
+      if (login?.error) throw new Error('Login failed');
+
+      router.push('/');
     } catch {
       setStatus('error');
       toast.error('Failed to set password');


### PR DESCRIPTION
## Summary
- fix `/api/set-password` by removing client-only calls and returning user email
- auto login user in `set-password` client page

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f4d31d9008332937c8476338f6bcf