### PR TITLE
Implement transactional username change

### DIFF
--- a/scripts/create-update-username-function.sql
+++ b/scripts/create-update-username-function.sql
@@ -1,0 +1,9 @@
+-- Function to update username in both users and profiles tables transactionally
+-- Run this in Supabase SQL editor or via supabase.rpc('exec_sql')
+CREATE OR REPLACE FUNCTION update_username(uid text, new_username text)
+RETURNS void AS $$
+BEGIN
+    UPDATE profiles SET username = new_username WHERE user_id = uid;
+    UPDATE users SET username = new_username WHERE id = uid;
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
## Summary
- ensure offensive usernames are blocked and only allow certain characters
- update username in both `profiles` and `users` tables in a single RPC call when possible
- add fallback logic to rollback if one update fails
- provide SQL script to create an `update_username` function

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f585290288332ab6b07bc926fcc3d