### PR TITLE
Fix username update logic

### DIFF
--- a/app/api/change-username/route.ts
+++ b/app/api/change-username/route.ts
@@ -60,19 +60,7 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: "Username taken" }, { status: 400 });
     }
 
-    // Try updating both tables in a single transaction via RPC
-    const { error: rpcError } = await supabase.rpc("update_username", {
-      uid: token.sub as string,
-      new_username: username,
-    });
-
-    if (!rpcError) {
-      return NextResponse.json({ success: true, username });
-    }
-
-    console.warn("update_username RPC failed, falling back", rpcError);
-
-    // Fallback: sequential updates with manual rollback if the second fails
+    // Get current username for potential rollback
     const { data: current, error: fetchOldErr } = await supabase
       .from("profiles")
       .select("username")


### PR DESCRIPTION
## Summary
- remove RPC call from change-username route
- check for existing usernames and update profiles and users directly
- rollback profile update if users update fails

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f5b5854dc8332aecd5d623ea9cc22