### PR TITLE
Fix password creation flow

### DIFF
--- a/app/api/set-password/route.ts
+++ b/app/api/set-password/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from "next/server";
 import bcrypt from "bcryptjs";
 import { createClient } from "@supabase/supabase-js";
+import { getServerSession } from "next-auth";
+import { authOptions } from "../../../lib/auth-options";
 
 const supabase = createClient(
   process.env.NEXT_PUBLIC_SUPABASE_URL!,
@@ -9,45 +11,27 @@ const supabase = createClient(
 
 export async function POST(req: Request) {
   try {
-    const { token, password } = await req.json().catch(() => ({}));
+    const session = await getServerSession({
+      ...authOptions,
+      secret: process.env.NEXTAUTH_SECRET,
+    });
 
-    if (!token || typeof token !== "string") {
-      return NextResponse.json({ error: "Missing token" }, { status: 400 });
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
     }
+
+    const { password } = await req.json().catch(() => ({}));
 
     if (!password || typeof password !== "string" || password.length < 6) {
       return NextResponse.json({ error: "Password too short" }, { status: 400 });
-    }
-
-    const { data: tokenRow } = await supabase
-      .from("password_reset_tokens")
-      .select("user_id, expires_at")
-      .eq("token", token)
-      .maybeSingle();
-
-    if (!tokenRow || new Date(tokenRow.expires_at).getTime() < Date.now()) {
-      return NextResponse.json(
-        { error: "Invalid or expired token" },
-        { status: 400 }
-      );
-    }
-
-    const { data: user } = await supabase
-      .from("users")
-      .select("email")
-      .eq("id", tokenRow.user_id)
-      .maybeSingle();
-
-    if (!user?.email) {
-      return NextResponse.json({ error: "User not found" }, { status: 404 });
     }
 
     const hashed = await bcrypt.hash(password, 12);
 
     const { error: updateErr } = await supabase
       .from("users")
-      .update({ hashed_password: hashed })
-      .eq("id", tokenRow.user_id);
+      .update({ hashed_password: hashed, has_password: true })
+      .eq("id", session.user.id);
 
     if (updateErr) {
       console.error("Error updating password:", updateErr);
@@ -57,9 +41,7 @@ export async function POST(req: Request) {
       );
     }
 
-    await supabase.from("password_reset_tokens").delete().eq("token", token);
-
-    return NextResponse.json({ success: true, email: user.email });
+    return NextResponse.json({ success: true });
   } catch (error) {
     console.error("Error in set-password route:", error);
     return NextResponse.json({ error: "Invalid request" }, { status: 400 });

--- a/app/set-password/ClientForm.tsx
+++ b/app/set-password/ClientForm.tsx
@@ -1,30 +1,24 @@
 // app/set-password/page.tsx
 "use client";
 import { useState } from "react";
-import { useSearchParams, useRouter } from "next/navigation";
+import { useRouter } from "next/navigation";
+import { signIn, useSession } from "next-auth/react";
+import PasswordInput from "@/components/PasswordInput";
 
 export default function SetPasswordPage() {
+  const { data: session } = useSession();
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
-  const [showPassword, setShowPassword] = useState(false);
   const [error, setError] = useState("");
   const [success, setSuccess] = useState("");
   const [loading, setLoading] = useState(false);
-  const searchParams = useSearchParams();
   const router = useRouter();
-  const token = searchParams.get("token");
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError("");
     setSuccess("");
     setLoading(true);
-
-    if (!token) {
-      setError("Invalid or missing token.");
-      setLoading(false);
-      return;
-    }
 
     if (password.length < 6) {
       setError("Password must be at least 6 characters.");
@@ -40,7 +34,7 @@ export default function SetPasswordPage() {
 
     const res = await fetch("/api/set-password", {
       method: "POST",
-      body: JSON.stringify({ token, password }),
+      body: JSON.stringify({ password }),
       headers: { "Content-Type": "application/json" },
     });
 
@@ -50,7 +44,12 @@ export default function SetPasswordPage() {
       setError(data.error || "Something went wrong.");
     } else {
       setSuccess("Password updated. Redirecting...");
-      setTimeout(() => router.push("/profile"), 1500);
+      await signIn("credentials", {
+        redirect: false,
+        email: session?.user.email!,
+        password,
+      });
+      router.push("/profile");
     }
 
     setLoading(false);
@@ -59,32 +58,24 @@ export default function SetPasswordPage() {
   return (
     <div className="max-w-md mx-auto mt-10 p-6 bg-white shadow rounded">
       <h1 className="text-xl font-bold mb-4">Set a New Password</h1>
+      <p className="text-sm text-gray-600 mb-4">
+        This will allow you to log in using your email and password in the future.
+      </p>
       <form onSubmit={handleSubmit} className="space-y-4">
         <div>
           <label className="block mb-1 font-medium">New Password</label>
-          <div className="relative">
-            <input
-              type={showPassword ? "text" : "password"}
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              className="w-full border px-4 py-2 rounded"
-              required
-              minLength={6}
-            />
-            <span
-              className="absolute right-3 top-2 cursor-pointer"
-              onClick={() => setShowPassword(!showPassword)}
-              title={showPassword ? "Hide" : "Show"}
-            >
-              👁
-            </span>
-          </div>
+          <PasswordInput
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="w-full border px-4 py-2 rounded"
+            required
+            minLength={6}
+          />
         </div>
 
         <div>
           <label className="block mb-1 font-medium">Confirm Password</label>
-          <input
-            type={showPassword ? "text" : "password"}
+          <PasswordInput
             value={confirmPassword}
             onChange={(e) => setConfirmPassword(e.target.value)}
             className="w-full border px-4 py-2 rounded"

--- a/lib/auth-options.ts
+++ b/lib/auth-options.ts
@@ -261,6 +261,17 @@ export const authOptions: NextAuthOptions = {
           user.email?.split("@")[0] ||
           "user_" + Math.random().toString(36).slice(2, 10);
       }
+
+      if (user) {
+        const { adminSupabase } = createSupabaseClients();
+        const { data } = await adminSupabase
+          .from("users")
+          .select("has_password")
+          .eq("id", user.id)
+          .single();
+        (token as any).has_password = data?.has_password ?? false;
+      }
+
       return token;
     },
     async session({ session, token }) {
@@ -272,8 +283,9 @@ export const authOptions: NextAuthOptions = {
           session.user.name = token.name as string;
           session.user.image = token.picture as string;
           (session.user as any).username = token.username as string;
+          (session.user as any).has_password = (token as any).has_password as boolean;
 
-          
+
         }
 
         return session;

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,13 +1,42 @@
 import { withAuth } from "next-auth/middleware";
+import { NextResponse } from "next/server";
 
-export default withAuth({
-  callbacks: {
-    authorized: ({ token }) => {
-      return !!token;
-    },
+export default withAuth(
+  function middleware(req) {
+    const token = req.nextauth.token as any;
+    const path = req.nextUrl.pathname;
+
+    if (
+      token &&
+      token.has_password === false &&
+      !path.startsWith("/set-password") &&
+      !path.startsWith("/api") &&
+      !path.startsWith("/_next") &&
+      path !== "/favicon.ico"
+    ) {
+      const url = req.nextUrl.clone();
+      url.pathname = "/set-password";
+      url.search = "";
+      return NextResponse.redirect(url);
+    }
   },
-});
+  {
+    callbacks: {
+      authorized: ({ token, req }) => {
+        const pathname = req.nextUrl.pathname;
+        if (
+          pathname.startsWith("/profile") ||
+          pathname.startsWith("/admin") ||
+          pathname.startsWith("/api/admin")
+        ) {
+          return !!token;
+        }
+        return true;
+      },
+    },
+  }
+);
 
 export const config = {
-  matcher: ["/profile/:path*", "/admin/:path*", "/api/admin/:path*"],
+  matcher: ["/(.*)"]
 };

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -4,12 +4,18 @@ declare module "next-auth" {
   interface Session {
     user: {
       id: string;
+      has_password: boolean;
     } & DefaultSession["user"];
-    requiresPasswordSetup?: boolean;
   }
 
   interface User extends DefaultUser {
     id: string;
+  }
+}
+
+declare module "next-auth/jwt" {
+  interface JWT {
+    has_password: boolean;
   }
 }
 


### PR DESCRIPTION
## Summary
- allow logged-in users to create a password
- ensure `/api/set-password` works with the session
- redirect to `/set-password` until password is set
- keep password state in auth token/session
- update types for `has_password`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686017308084833287d195b2fbf67ddb